### PR TITLE
Add `workflows` alias.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Enable OID4VCI+OID4VP flows that include providing an OID4VP
   authorization request during a credential request that must be
   fulfilled prior to accepting the credential request(s).
+- Expose `exchangers` base route as `workflows`, keeping `exchangers` as a
+  deprecated alias.
 
 ## 4.3.0 - 2023-12-11
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,19 +1,31 @@
 /*!
- * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 
+const c = bedrock.util.config.main;
+const cc = c.computer();
 const {config} = bedrock;
 
-// use `vc-exchanger` namespace
-const namespace = 'vc-exchanger';
+// use `vc-workflow` namespace
+const namespace = 'vc-workflow';
 config[namespace] = {};
 
-// create dev application identity for vc-exchanger (must be overridden in
+// create dev application identity for vc-workflow (must be overridden in
 // deployments) ...and `ensureConfigOverride` has already been set via
 // `bedrock-app-identity` so it doesn't have to be set here
-config['app-identity'].seeds.services['vc-exchanger'] = {
+config['app-identity'].seeds.services['vc-workflow'] = {
   id: 'did:key:z6MknmKKxYiYo6txxX2bCgzeuBDkPPb5SJ36p232XkVEk7mf',
   seedMultibase: 'z1Abgbd91bbZHPYakVA7EPvhY9NZ2EaTkEpmwdBCfifokDn',
+  serviceType: 'vc-workflow'
+};
+
+// backwards compatibility: `vc-exchanger` alias:
+cc('vc-exchanger', () => config[namespace]);
+config['app-identity'].seeds.services['vc-exchanger'] = {
   serviceType: 'vc-exchanger'
 };
+cc('app-identity.seeds.services.vc-exchanger.id', () =>
+  config['app-identity'].seeds.services['vc-workflow'].id);
+cc('app-identity.seeds.services.vc-exchanger.seedMultibase', () =>
+  config['app-identity'].seeds.services['vc-workflow'].seedMultibase);

--- a/lib/exchanges.js
+++ b/lib/exchanges.js
@@ -32,7 +32,20 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
   await database.openCollections([COLLECTION_NAME]);
 
   await database.createIndexes([{
-    // cover exchange queries by exchanger ID + exchange ID
+    // cover exchange queries by local workflow ID + exchange ID
+    collection: COLLECTION_NAME,
+    fields: {localWorkflowId: 1, 'exchange.id': 1},
+    options: {
+      partialFilterExpression: {
+        localWorkflowId: {$exists: true}
+      },
+      unique: true, background: false
+    }
+  }, {
+    // backwards compatibility: cover exchange queries by
+    // local exchanger ID + exchange ID; local exchanger ID is the same as
+    // local workflow ID and this index can be eventually dropped once no
+    // deployments use `localExchangerId`
     collection: COLLECTION_NAME,
     fields: {localExchangerId: 1, 'exchange.id': 1},
     options: {unique: true, background: false}
@@ -79,9 +92,11 @@ export async function insert({exchangerId, exchange}) {
     // TTL is in seconds
     meta.expires = new Date(now + exchange.ttl * 1000);
   }
-  const {localId: localExchangerId} = parseLocalId({id: exchangerId});
+  const {localId: localWorkflowId} = parseLocalId({id: exchangerId});
   const record = {
-    localExchangerId,
+    localWorkflowId,
+    // backwards compatibility: enable existing systems to find record
+    localExchangerId: localWorkflowId,
     meta,
     // possible states are: `pending`, `active`, `complete`, or `invalid`
     exchange: {...exchange, sequence: 0, state: 'pending'}
@@ -123,14 +138,19 @@ export async function get({exchangerId, id, explain = false} = {}) {
   assert.string(exchangerId, 'exchangerId');
   assert.string(id, 'id');
 
-  const {localId: localExchangerId} = parseLocalId({id: exchangerId});
+  const {base, localId: localWorkflowId} = parseLocalId({id: exchangerId});
   const collection = database.collections[COLLECTION_NAME];
   const query = {
-    localExchangerId,
+    localWorkflowId,
     'exchange.id': id,
     // treat exchange as not found if invalid
     'exchange.state': {$ne: 'invalid'}
   };
+  // backwards compatibility: query on `localExchangerId`
+  if(base.endsWith('/exchangers')) {
+    query.localWorkflowId = {$in: [null, localWorkflowId]};
+    query.localExchangerId = localWorkflowId;
+  }
   const projection = {_id: 0, exchange: 1, meta: 1};
 
   if(explain) {
@@ -155,11 +175,18 @@ export async function get({exchangerId, id, explain = false} = {}) {
 
   // backwards compatibility; initialize `sequence`
   if(record.exchange.sequence === undefined) {
-    await collection.updateOne({
-      localExchangerId,
+    const query = {
+      localWorkflowId,
       'exchange.id': id,
       'exchange.sequence': null
-    }, {$set: {'exchange.sequence': 0}});
+    };
+    // backwards compatibility: query on `localExchangerId`
+    if(base.endsWith('/exchangers')) {
+      query.localWorkflowId = {$in: [null, localWorkflowId]};
+      query.localExchangerId = localWorkflowId;
+    }
+
+    await collection.updateOne(query, {$set: {'exchange.sequence': 0}});
     record.exchange.sequence = 0;
   }
 
@@ -201,17 +228,22 @@ export async function update({exchangerId, exchange, explain = false} = {}) {
     update.$set['exchange.ttl'] = exchange.ttl;
   }
 
-  const {localId: localExchangerId} = parseLocalId({id: exchangerId});
+  const {base, localId: localWorkflowId} = parseLocalId({id: exchangerId});
 
   const collection = database.collections[COLLECTION_NAME];
   const query = {
-    localExchangerId,
+    localWorkflowId,
     'exchange.id': id,
     // exchange sequence must match previous sequence
     'exchange.sequence': exchange.sequence - 1,
     // previous state must be `pending` or `active` in order to update it
     'exchange.state': {$in: ['pending', 'active']}
   };
+  // backwards compatibility: query on `localExchangerId`
+  if(base.endsWith('/exchangers')) {
+    query.localWorkflowId = {$in: [null, localWorkflowId]};
+    query.localExchangerId = localWorkflowId;
+  }
 
   if(explain) {
     // 'find().limit(1)' is used here because 'updateOne()' doesn't return a
@@ -292,11 +324,11 @@ export async function complete({exchangerId, exchange, explain = false} = {}) {
     update.$set['exchange.ttl'] = exchange.ttl;
   }
 
-  const {localId: localExchangerId} = parseLocalId({id: exchangerId});
+  const {base, localId: localWorkflowId} = parseLocalId({id: exchangerId});
 
   const collection = database.collections[COLLECTION_NAME];
   const query = {
-    localExchangerId,
+    localWorkflowId,
     'exchange.id': id,
     // exchange sequence must match previous sequence
     'exchange.sequence': exchange.sequence - 1,
@@ -304,6 +336,11 @@ export async function complete({exchangerId, exchange, explain = false} = {}) {
     // `complete`
     'exchange.state': {$in: ['pending', 'active']}
   };
+  // backwards compatibility: query on `localExchangerId`
+  if(base.endsWith('/exchangers')) {
+    query.localWorkflowId = {$in: [null, localWorkflowId]};
+    query.localExchangerId = localWorkflowId;
+  }
 
   if(explain) {
     // 'find().limit(1)' is used here because 'updateOne()' doesn't return a
@@ -390,9 +427,13 @@ async function _markExchangeInvalid({record}) {
   // mark exchange invalid
   try {
     const query = {
-      localExchangerId: record.localExchangerId,
+      localWorkflowId: record.localWorkflowId,
       'exchange.id': record.exchange.id
     };
+    // backwards compatibility: query on `localExchangerId`
+    if(!record.localWorkflowId) {
+      query.localExchangerId = record.localExchangerId;
+    }
     const update = {
       $set: {
         'exchange.state': 'invalid',

--- a/lib/exchanges.js
+++ b/lib/exchanges.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import * as database from '@bedrock/mongodb';

--- a/lib/exchanges.js
+++ b/lib/exchanges.js
@@ -68,14 +68,14 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
  * Inserts an exchange record.
  *
  * @param {object} options - The options to use.
- * @param {string} options.exchangerId - The ID of the exchanger that the
+ * @param {string} options.workflowId - The ID of the workflow that the
  *   exchange is associated with.
  * @param {object} options.exchange - The exchange to insert.
  *
  * @returns {Promise<object>} Resolves to the database record.
  */
-export async function insert({exchangerId, exchange}) {
-  assert.string(exchangerId, 'exchangerId');
+export async function insert({workflowId, exchange}) {
+  assert.string(workflowId, 'workflowId');
   assert.object(exchange, 'exchange');
   assert.string(exchange.id, 'exchange.id');
   // optional time to live in seconds
@@ -92,7 +92,7 @@ export async function insert({exchangerId, exchange}) {
     // TTL is in seconds
     meta.expires = new Date(now + exchange.ttl * 1000);
   }
-  const {localId: localWorkflowId} = parseLocalId({id: exchangerId});
+  const {localId: localWorkflowId} = parseLocalId({id: workflowId});
   const record = {
     localWorkflowId,
     // backwards compatibility: enable existing systems to find record
@@ -126,7 +126,7 @@ export async function insert({exchangerId, exchange}) {
  * Gets an exchange record.
  *
  * @param {object} options - The options to use.
- * @param {string} options.exchangerId - The ID of the exchanger that the
+ * @param {string} options.workflowId - The ID of the workflow that the
  *   exchange is associated with.
  * @param {string} options.id - The ID of the exchange to retrieve.
  * @param {boolean} [options.explain=false] - An optional explain boolean.
@@ -134,11 +134,11 @@ export async function insert({exchangerId, exchange}) {
  * @returns {Promise<object | ExplainObject>} Resolves with the record that
  *   matches the query or an ExplainObject if `explain=true`.
  */
-export async function get({exchangerId, id, explain = false} = {}) {
-  assert.string(exchangerId, 'exchangerId');
+export async function get({workflowId, id, explain = false} = {}) {
+  assert.string(workflowId, 'workflowId');
   assert.string(id, 'id');
 
-  const {base, localId: localWorkflowId} = parseLocalId({id: exchangerId});
+  const {base, localId: localWorkflowId} = parseLocalId({id: workflowId});
   const collection = database.collections[COLLECTION_NAME];
   const query = {
     localWorkflowId,
@@ -165,7 +165,9 @@ export async function get({exchangerId, id, explain = false} = {}) {
     throw new BedrockError('Exchange not found.', {
       name: 'NotFoundError',
       details: {
-        exchanger: exchangerId,
+        workflow: workflowId,
+        // backwards compatibility
+        exchanger: workflowId,
         exchange: id,
         httpStatusCode: 404,
         public: true
@@ -198,7 +200,7 @@ export async function get({exchangerId, id, explain = false} = {}) {
  * information.
  *
  * @param {object} options - The options to use.
- * @param {string} options.exchangerId - The ID of the exchanger the exchange
+ * @param {string} options.workflowId - The ID of the workflow the exchange
  *   is associated with.
  * @param {object} options.exchange - The exchange to update.
  * @param {boolean} [options.explain=false] - An optional explain boolean.
@@ -206,8 +208,8 @@ export async function get({exchangerId, id, explain = false} = {}) {
  * @returns {Promise<boolean | ExplainObject>} Resolves with `true` on update
  *   success or an ExplainObject if `explain=true`.
  */
-export async function update({exchangerId, exchange, explain = false} = {}) {
-  assert.string(exchangerId, 'exchangerId');
+export async function update({workflowId, exchange, explain = false} = {}) {
+  assert.string(workflowId, 'workflowId');
   assert.object(exchange, 'exchange');
   const {id} = exchange;
 
@@ -228,7 +230,7 @@ export async function update({exchangerId, exchange, explain = false} = {}) {
     update.$set['exchange.ttl'] = exchange.ttl;
   }
 
-  const {base, localId: localWorkflowId} = parseLocalId({id: exchangerId});
+  const {base, localId: localWorkflowId} = parseLocalId({id: workflowId});
 
   const collection = database.collections[COLLECTION_NAME];
   const query = {
@@ -271,7 +273,7 @@ export async function update({exchangerId, exchange, explain = false} = {}) {
 
   // if no document was matched, try to get an existing exchange; if the
   // exchange does not exist, a not found error will be automatically thrown
-  await get({exchangerId, id});
+  await get({workflowId, id});
 
   /* Note: Here the exchange *does* exist, but the step or state did not
   match which is a conflict error. */
@@ -291,7 +293,7 @@ export async function update({exchangerId, exchange, explain = false} = {}) {
  * Marks an exchange as complete.
  *
  * @param {object} options - The options to use.
- * @param {string} options.exchangerId - The ID of the exchanger the exchange
+ * @param {string} options.workflowId - The ID of the workflow the exchange
  *   is associated with.
  * @param {object} options.exchange - The exchange to mark as complete.
  * @param {boolean} [options.explain=false] - An optional explain boolean.
@@ -299,8 +301,8 @@ export async function update({exchangerId, exchange, explain = false} = {}) {
  * @returns {Promise<boolean | ExplainObject>} Resolves with `true` on update
  *   success or an ExplainObject if `explain=true`.
  */
-export async function complete({exchangerId, exchange, explain = false} = {}) {
-  assert.string(exchangerId, 'exchangerId');
+export async function complete({workflowId, exchange, explain = false} = {}) {
+  assert.string(workflowId, 'workflowId');
   assert.object(exchange, 'exchange');
   const {id} = exchange;
 
@@ -324,7 +326,7 @@ export async function complete({exchangerId, exchange, explain = false} = {}) {
     update.$set['exchange.ttl'] = exchange.ttl;
   }
 
-  const {base, localId: localWorkflowId} = parseLocalId({id: exchangerId});
+  const {base, localId: localWorkflowId} = parseLocalId({id: workflowId});
 
   const collection = database.collections[COLLECTION_NAME];
   const query = {
@@ -368,7 +370,7 @@ export async function complete({exchangerId, exchange, explain = false} = {}) {
 
   // if no document was matched, try to get an existing exchange; if the
   // exchange does not exist, a not found error will be automatically thrown
-  const record = await get({exchangerId, id});
+  const record = await get({workflowId, id});
 
   /* Note: Here the exchange *does* exist, but couldn't be updated because
   another process changed it. That change either left it in a still pending

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,7 +12,7 @@ import {ZcapClient} from '@digitalbazaar/ezcap';
 const {config} = bedrock;
 
 export async function evaluateTemplate({
-  exchanger, exchange, typedTemplate
+  workflow, exchange, typedTemplate
 } = {}) {
   // run jsonata compiler; only `jsonata` template type is supported and this
   // assumes only this template type will be passed in
@@ -20,8 +20,12 @@ export async function evaluateTemplate({
   const {variables = {}} = exchange;
   // always include `globals` as keyword for self-referencing exchange info
   variables.globals = {
+    workflow: {
+      id: workflow.id
+    },
+    // backwards compatibility
     exchanger: {
-      id: exchanger.id
+      id: workflow.id
     },
     exchange: {
       id: exchange.id
@@ -30,7 +34,7 @@ export async function evaluateTemplate({
   return jsonata(template).evaluate(variables, variables);
 }
 
-export function getExchangerId({routePrefix, localId} = {}) {
+export function getWorkflowId({routePrefix, localId} = {}) {
   return `${config.server.baseUri}${routePrefix}/${localId}`;
 }
 
@@ -44,15 +48,15 @@ export async function generateRandom() {
   });
 }
 
-export async function getZcapClient({exchanger} = {}) {
+export async function getZcapClient({workflow} = {}) {
   // get service agent for communicating with the issuer instance
-  const {pathname} = new URL(exchanger.id);
+  const {pathname} = new URL(workflow.id);
   // backwards-compatibility: support deprecated `vc-exchanger`
   const serviceType = pathname.startsWith('/workflows/') ?
     'vc-workflow' : 'vc-exchanger';
   const {serviceAgent} = await serviceAgents.get({serviceType});
   const {capabilityAgent, zcaps} = await serviceAgents.getEphemeralAgent(
-    {config: exchanger, serviceAgent});
+    {config: workflow, serviceAgent});
 
   // create zcap client for issuing VCs
   const zcapClient = new ZcapClient({

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import {decodeId, generateId} from 'bnid';
@@ -46,8 +46,11 @@ export async function generateRandom() {
 
 export async function getZcapClient({exchanger} = {}) {
   // get service agent for communicating with the issuer instance
-  const {serviceAgent} = await serviceAgents.get(
-    {serviceType: 'vc-exchanger'});
+  const {pathname} = new URL(exchanger.id);
+  // backwards-compatibility: support deprecated `vc-exchanger`
+  const serviceType = pathname.startsWith('/workflows/') ?
+    'vc-workflow' : 'vc-exchanger';
+  const {serviceAgent} = await serviceAgents.get({serviceType});
   const {capabilityAgent, zcaps} = await serviceAgents.getEphemeralAgent(
     {config: exchanger, serviceAgent});
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -8,7 +8,7 @@ import {
   createExchangeBody, useExchangeBody
 } from '../schemas/bedrock-vc-workflow.js';
 import {exportJWK, generateKeyPair, importJWK} from 'jose';
-import {generateRandom, getExchangerId} from './helpers.js';
+import {generateRandom, getWorkflowId} from './helpers.js';
 import {metering, middleware} from '@bedrock/service-core';
 import {asyncHandler} from '@bedrock/express';
 import bodyParser from 'body-parser';
@@ -38,15 +38,15 @@ export async function addRoutes({app, service} = {}) {
     exchange: `${baseUrl}/exchanges/:exchangeId`
   };
 
-  // used to retrieve service object (exchanger) config
+  // used to retrieve service object (workflow) config
   const getConfigMiddleware = middleware.createGetConfigMiddleware({service});
 
   // used to fetch exchange record in parallel
   const getExchange = asyncHandler(async (req, res, next) => {
     const {localId, exchangeId: id} = req.params;
-    const exchangerId = getExchangerId({routePrefix, localId});
+    const workflowId = getWorkflowId({routePrefix, localId});
     // expose access to result via `req`; do not wait for it to settle here
-    const exchangePromise = exchanges.get({exchangerId, id}).catch(e => e);
+    const exchangePromise = exchanges.get({workflowId, id}).catch(e => e);
     req.getExchange = async () => {
       const record = await exchangePromise;
       if(record instanceof Error) {
@@ -117,7 +117,7 @@ export async function addRoutes({app, service} = {}) {
         }
 
         // insert exchange
-        const {id: exchangerId} = config;
+        const {id: workflowId} = config;
         const exchange = {
           id: await generateRandom(),
           ttl,
@@ -125,8 +125,8 @@ export async function addRoutes({app, service} = {}) {
           openId,
           step
         };
-        await exchanges.insert({exchangerId, exchange});
-        const location = `${exchangerId}/exchanges/${exchange.id}`;
+        await exchanges.insert({workflowId, exchange});
+        const location = `${workflowId}/exchanges/${exchange.id}`;
         res.status(204).location(location).send();
       } catch(error) {
         logger.error(error.message, {error});
@@ -160,9 +160,9 @@ export async function addRoutes({app, service} = {}) {
     getExchange,
     getConfigMiddleware,
     asyncHandler(async (req, res) => {
-      const {config: exchanger} = req.serviceObject;
+      const {config: workflow} = req.serviceObject;
       const {exchange} = await req.getExchange();
-      await processExchange({req, res, exchanger, exchange});
+      await processExchange({req, res, workflow, exchange});
     }));
 
   // create OID4VCI routes to be used with each individual exchange

--- a/lib/http.js
+++ b/lib/http.js
@@ -6,7 +6,7 @@ import * as bedrock from '@bedrock/core';
 import * as exchanges from './exchanges.js';
 import {
   createExchangeBody, useExchangeBody
-} from '../schemas/bedrock-vc-exchanger.js';
+} from '../schemas/bedrock-vc-workflow.js';
 import {exportJWK, generateKeyPair, importJWK} from 'jose';
 import {generateRandom, getExchangerId} from './helpers.js';
 import {metering, middleware} from '@bedrock/service-core';

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
-import * as exchangerSchemas from '../schemas/bedrock-vc-exchanger.js';
+import * as exchangerSchemas from '../schemas/bedrock-vc-workflow.js';
 import {createService, schemas} from '@bedrock/service-core';
 import {addRoutes} from './http.js';
 import {initializeServiceAgent} from '@bedrock/service-agent';
@@ -13,11 +13,17 @@ import '@bedrock/express';
 // load config defaults
 import './config.js';
 
-const routePrefix = '/exchangers';
-const serviceType = 'vc-exchanger';
+// const routePrefix = '/exchangers';
+// const serviceType = 'vc-exchanger';
 const {util: {BedrockError}} = bedrock;
 
 bedrock.events.on('bedrock.init', async () => {
+  await _initService({serviceType: 'vc-workflow', routePrefix: '/workflows'});
+  // backwards compatibility: deprecrated `exchangers` service
+  await _initService({serviceType: 'vc-exchanger', routePrefix: '/exchangers'});
+});
+
+async function _initService({serviceType, routePrefix}) {
   // add customizations to config validators...
   const createConfigBody = klona(schemas.createConfigBody);
   const updateConfigBody = klona(schemas.updateConfigBody);
@@ -48,7 +54,9 @@ bedrock.events.on('bedrock.init', async () => {
     validation: {
       createConfigBody,
       updateConfigBody,
-      validateConfigFn,
+      async validateConfigFn({config, op} = {}) {
+        return validateConfigFn({config, op, routePrefix});
+      },
       // these zcaps are optional (by reference ID)
       zcapReferenceIds: [{
         referenceId: 'issue',
@@ -73,7 +81,7 @@ bedrock.events.on('bedrock.init', async () => {
     await addRoutes({app, service});
   });
 
-  // initialize vc-exchanger service agent early (after database is ready) if
+  // initialize vc-workflow service agent early (after database is ready) if
   // KMS system is externalized; otherwise we must wait until KMS system
   // is ready
   const externalKms = !bedrock.config['service-agent'].kms.baseUrl.startsWith(
@@ -82,7 +90,7 @@ bedrock.events.on('bedrock.init', async () => {
   bedrock.events.on(event, async () => {
     await initializeServiceAgent({serviceType});
   });
-});
+}
 
 async function usageAggregator({meter, signal, service} = {}) {
   const {id: meterId} = meter;
@@ -90,12 +98,12 @@ async function usageAggregator({meter, signal, service} = {}) {
   return service.configStorage.getUsage({meterId, signal});
 }
 
-async function validateConfigFn({config, op} = {}) {
+async function validateConfigFn({config, op, routePrefix} = {}) {
   try {
     // validate any `id` in a new config
     if(op === 'create' && config.id !== undefined) {
       try {
-        _validateId({id: config.id});
+        _validateId({id: config.id, routePrefix});
       } catch(e) {
         throw new BedrockError(
           `Invalid client-provided configuration ID: ${e.message}.`, {
@@ -142,7 +150,7 @@ async function validateConfigFn({config, op} = {}) {
   return {valid: true};
 }
 
-function _validateId({id} = {}) {
+function _validateId({id, routePrefix} = {}) {
   // format: <base>/<localId>
 
   // ensure `id` starts with appropriate base URL

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
-import * as exchangerSchemas from '../schemas/bedrock-vc-workflow.js';
+import * as workflowSchemas from '../schemas/bedrock-vc-workflow.js';
 import {createService, schemas} from '@bedrock/service-core';
 import {addRoutes} from './http.js';
 import {initializeServiceAgent} from '@bedrock/service-agent';
@@ -13,8 +13,6 @@ import '@bedrock/express';
 // load config defaults
 import './config.js';
 
-// const routePrefix = '/exchangers';
-// const serviceType = 'vc-exchanger';
 const {util: {BedrockError}} = bedrock;
 
 bedrock.events.on('bedrock.init', async () => {
@@ -28,9 +26,9 @@ async function _initService({serviceType, routePrefix}) {
   const createConfigBody = klona(schemas.createConfigBody);
   const updateConfigBody = klona(schemas.updateConfigBody);
   const schemasToUpdate = [createConfigBody, updateConfigBody];
-  const {credentialTemplates, steps, initialStep} = exchangerSchemas;
+  const {credentialTemplates, steps, initialStep} = workflowSchemas;
   for(const schema of schemasToUpdate) {
-    // add config requirements to exchanger configs
+    // add config requirements to workflow configs
     schema.properties.credentialTemplates = credentialTemplates;
     schema.properties.steps = steps;
     schema.properties.initialStep = initialStep;
@@ -43,7 +41,7 @@ async function _initService({serviceType, routePrefix}) {
   // below in `validateConfigFn`
   createConfigBody.properties.id = updateConfigBody.properties.id;
 
-  // create `vc-exchanger` service
+  // create workflow service
   const service = await createService({
     serviceType,
     routePrefix,

--- a/lib/issue.js
+++ b/lib/issue.js
@@ -4,11 +4,11 @@
 import {evaluateTemplate, getZcapClient} from './helpers.js';
 import {createPresentation} from '@digitalbazaar/vc';
 
-export async function issue({exchanger, exchange} = {}) {
-  // use any templates from exchanger and variables from exchange to produce
+export async function issue({workflow, exchange} = {}) {
+  // use any templates from workflow and variables from exchange to produce
   // credentials to be issued; issue via the configured issuer instance
   const verifiableCredential = [];
-  const {credentialTemplates = []} = exchanger;
+  const {credentialTemplates = []} = workflow;
   if(!credentialTemplates || credentialTemplates.length === 0) {
     // nothing to issue
     return {};
@@ -16,9 +16,9 @@ export async function issue({exchanger, exchange} = {}) {
 
   // evaluate template
   const credentialRequests = await Promise.all(credentialTemplates.map(
-    typedTemplate => evaluateTemplate({exchanger, exchange, typedTemplate})));
+    typedTemplate => evaluateTemplate({workflow, exchange, typedTemplate})));
   // issue all VCs
-  const vcs = await _issue({exchanger, credentialRequests});
+  const vcs = await _issue({workflow, credentialRequests});
   verifiableCredential.push(...vcs);
 
   // generate VP to return VCs
@@ -32,9 +32,9 @@ export async function issue({exchanger, exchange} = {}) {
   return {verifiablePresentation};
 }
 
-async function _issue({exchanger, credentialRequests} = {}) {
+async function _issue({workflow, credentialRequests} = {}) {
   // create zcap client for issuing VCs
-  const {zcapClient, zcaps} = await getZcapClient({exchanger});
+  const {zcapClient, zcaps} = await getZcapClient({workflow});
 
   // issue VCs in parallel
   const capability = zcaps.issue;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,6 @@
 /*!
- * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import {loggers} from '@bedrock/core';
 
-export const logger = loggers.get('app').child('bedrock-vc-exchanger');
+export const logger = loggers.get('app').child('bedrock-vc-workflow');

--- a/lib/openId.js
+++ b/lib/openId.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import * as exchanges from './exchanges.js';
@@ -13,7 +13,7 @@ import {
   openIdCredentialBody,
   openIdTokenBody,
   presentationSubmission as presentationSubmissionSchema
-} from '../schemas/bedrock-vc-exchanger.js';
+} from '../schemas/bedrock-vc-workflow.js';
 import {verify, verifyDidProofJwt} from './verify.js';
 import {asyncHandler} from '@bedrock/express';
 import bodyParser from 'body-parser';

--- a/lib/openId.js
+++ b/lib/openId.js
@@ -90,15 +90,15 @@ export async function createRoutes({
 
   // an authorization server meta data endpoint
   // serves `.well-known` oauth2 AS config for each exchange; each config is
-  // based on the exchanger used to create the exchange
+  // based on the workflow used to create the exchange
   app.get(
     routes.asMetadata,
     cors(),
     getConfigMiddleware,
     asyncHandler(async (req, res) => {
       // generate well-known oauth2 issuer config
-      const {config: exchanger} = req.serviceObject;
-      const exchangeId = `${exchanger.id}/exchanges/${req.params.exchangeId}`;
+      const {config: workflow} = req.serviceObject;
+      const exchangeId = `${workflow.id}/exchanges/${req.params.exchangeId}`;
       // note that technically, we should not need to serve any credential
       // issuer metadata, but we do for backwards compatibility purposes as
       // previous versions of OID4VCI required it
@@ -114,15 +114,15 @@ export async function createRoutes({
 
   // a credential issuer meta data endpoint
   // serves `.well-known` oauth2 AS / CI config for each exchange; each config
-  // is based on the exchanger used to create the exchange
+  // is based on the workflow used to create the exchange
   app.get(
     routes.ciMetadata,
     cors(),
     getConfigMiddleware,
     asyncHandler(async (req, res) => {
       // generate well-known oauth2 issuer config
-      const {config: exchanger} = req.serviceObject;
-      const exchangeId = `${exchanger.id}/exchanges/${req.params.exchangeId}`;
+      const {config: workflow} = req.serviceObject;
+      const exchangeId = `${workflow.id}/exchanges/${req.params.exchangeId}`;
       const oauth2Config = {
         issuer: exchangeId,
         jwks_uri: `${exchangeId}/openid/jwks`,
@@ -135,7 +135,7 @@ export async function createRoutes({
 
   // an authorization server endpoint
   // serves JWKs associated with each exchange; JWKs are stored with the
-  // exchanger used to create the exchange
+  // workflow used to create the exchange
   app.get(
     routes.jwks,
     cors(),
@@ -204,9 +204,9 @@ export async function createRoutes({
       }
 
       // create access token
-      const {config: exchanger} = req.serviceObject;
+      const {config: workflow} = req.serviceObject;
       const {accessToken, ttl} = await _createExchangeAccessToken(
-        {exchanger, exchangeRecord});
+        {workflow, exchangeRecord});
 
       // send response
       const body = {
@@ -263,7 +263,7 @@ export async function createRoutes({
       res.json({
         format: 'ldp_vc',
         /* Note: The `/credential` route only supports sending a single VC;
-        assume here that this exchanger is configured for a single VC and an
+        assume here that this workflow is configured for a single VC and an
         error code would have been sent to the client to use the batch
         endpoint if there was more than one VC to deliver. */
         credential: result.verifiablePresentation.verifiableCredential[0]
@@ -368,15 +368,15 @@ export async function createRoutes({
 
   // an authorization server meta data endpoint
   // serves `.well-known` oauth2 AS config for each exchange; each config is
-  // based on the exchanger used to create the exchange
+  // based on the workflow used to create the exchange
   app.get(
     routes.asMetadataDraftBug,
     cors(),
     getConfigMiddleware,
     asyncHandler(async (req, res) => {
       // generate well-known oauth2 issuer config
-      const {config: exchanger} = req.serviceObject;
-      const exchangeId = `${exchanger.id}/exchanges/${req.params.exchangeId}`;
+      const {config: workflow} = req.serviceObject;
+      const exchangeId = `${workflow.id}/exchanges/${req.params.exchangeId}`;
       // note that technically, we should not need to serve any credential
       // issuer metadata, but we do for backwards compatibility purposes as
       // previous versions of OID4VCI required it
@@ -392,15 +392,15 @@ export async function createRoutes({
 
   // a credential issuer meta data endpoint
   // serves `.well-known` oauth2 AS / CI config for each exchange; each config
-  // is based on the exchanger used to create the exchange
+  // is based on the workflow used to create the exchange
   app.get(
     routes.ciMetadataDraftBug,
     cors(),
     getConfigMiddleware,
     asyncHandler(async (req, res) => {
       // generate well-known oauth2 issuer config
-      const {config: exchanger} = req.serviceObject;
-      const exchangeId = `${exchanger.id}/exchanges/${req.params.exchangeId}`;
+      const {config: workflow} = req.serviceObject;
+      const exchangeId = `${workflow.id}/exchanges/${req.params.exchangeId}`;
       const oauth2Config = {
         issuer: exchangeId,
         jwks_uri: `${exchangeId}/openid/jwks`,
@@ -412,7 +412,7 @@ export async function createRoutes({
     }));
 }
 
-async function _createExchangeAccessToken({exchanger, exchangeRecord}) {
+async function _createExchangeAccessToken({workflow, exchangeRecord}) {
   // FIXME: set `exp` to max of 15 minutes / configured max minutes
   const expires = exchangeRecord.meta.expires;
   const exp = Math.floor(expires.getTime() / 1000);
@@ -420,7 +420,7 @@ async function _createExchangeAccessToken({exchanger, exchangeRecord}) {
   // create access token
   const {exchange} = exchangeRecord;
   const {openId: {oauth2: {keyPair: {privateKeyJwk}}}} = exchange;
-  const exchangeId = `${exchanger.id}/exchanges/${exchange.id}`;
+  const exchangeId = `${workflow.id}/exchanges/${exchange.id}`;
   const {accessToken, ttl} = await _createOAuth2AccessToken({
     privateKeyJwk, audience: exchangeId, action: 'write', target: exchangeId,
     exp, iss: exchangeId
@@ -454,7 +454,7 @@ async function _createOAuth2AccessToken({
   return {accessToken, ttl};
 }
 
-async function _checkAuthz({req, exchanger, exchange}) {
+async function _checkAuthz({req, workflow, exchange}) {
   // optional oauth2 options
   const {oauth2} = exchange.openId;
   const {maxClockSkew} = oauth2;
@@ -462,7 +462,7 @@ async function _checkAuthz({req, exchanger, exchange}) {
   // audience is always the `exchangeId` and cannot be configured; this
   // prevents attacks where access tokens could otherwise be generated
   // if the AS keys were compromised; the `exchangeId` must also be known
-  const exchangeId = `${exchanger.id}/exchanges/${req.params.exchangeId}`;
+  const exchangeId = `${workflow.id}/exchanges/${req.params.exchangeId}`;
   const audience = exchangeId;
 
   // `issuerConfigUrl` is always based off of the `exchangeId` as well
@@ -500,7 +500,7 @@ function _getAlgFromPrivateKey({privateKeyJwk}) {
 }
 
 async function _processCredentialRequests({req, res, isBatchRequest}) {
-  const {config: exchanger} = req.serviceObject;
+  const {config: workflow} = req.serviceObject;
   const exchangeRecord = await req.getExchange();
   const {exchange} = exchangeRecord;
   if(!exchange.openId) {
@@ -508,7 +508,7 @@ async function _processCredentialRequests({req, res, isBatchRequest}) {
   }
 
   // ensure oauth2 access token is valid
-  await _checkAuthz({req, exchanger, exchange});
+  await _checkAuthz({req, workflow, exchange});
 
   // validate body against expected credential requests
   const {openId: {expectedCredentialRequests}} = exchange;
@@ -535,12 +535,12 @@ async function _processCredentialRequests({req, res, isBatchRequest}) {
   // process exchange step if present
   const currentStep = exchange.step;
   if(currentStep) {
-    let step = exchanger.steps[exchange.step];
+    let step = workflow.steps[exchange.step];
     if(step.stepTemplate) {
       // generate step from the template; assume the template type is
       // `jsonata` per the JSON schema
       step = await evaluateTemplate(
-        {exchanger, exchange, typedTemplate: step.stepTemplate});
+        {workflow, exchange, typedTemplate: step.stepTemplate});
       if(Object.keys(step).length === 0) {
         throw new BedrockError('Could not create exchange step.', {
           name: 'DataError',
@@ -585,7 +585,7 @@ async function _processCredentialRequests({req, res, isBatchRequest}) {
       const results = await Promise.all(
         credentialRequests.map(async cr => {
           const {proof: {jwt}} = cr;
-          const {did} = await verifyDidProofJwt({exchanger, exchange, jwt});
+          const {did} = await verifyDidProofJwt({workflow, exchange, jwt});
           return did;
         }));
       // require `did` to be the same for every proof
@@ -609,13 +609,13 @@ async function _processCredentialRequests({req, res, isBatchRequest}) {
 
   // mark exchange complete
   exchange.sequence++;
-  await exchanges.complete({exchangerId: exchanger.id, exchange});
+  await exchanges.complete({workflowId: workflow.id, exchange});
 
   // FIXME: decide what the best recovery path is if delivery fails (but no
   // replay attack detected) after exchange has been marked complete
 
   // issue VCs
-  return issue({exchanger, exchange});
+  return issue({workflow, exchange});
 }
 
 async function _requestDidProof({res, exchangeRecord}) {
@@ -685,7 +685,7 @@ async function _requestOID4VP({authorizationRequest, res}) {
 }
 
 async function _getAuthorizationRequest({req}) {
-  const {config: exchanger} = req.serviceObject;
+  const {config: workflow} = req.serviceObject;
   const exchangeRecord = await req.getExchange();
   let {exchange} = exchangeRecord;
   let step;
@@ -697,12 +697,12 @@ async function _getAuthorizationRequest({req}) {
       _throwUnsupportedProtocol();
     }
 
-    step = exchanger.steps[exchange.step];
+    step = workflow.steps[exchange.step];
     if(step.stepTemplate) {
       // generate step from the template; assume the template type is
       // `jsonata` per the JSON schema
       step = await evaluateTemplate(
-        {exchanger, exchange, typedTemplate: step.stepTemplate});
+        {workflow, exchange, typedTemplate: step.stepTemplate});
       if(Object.keys(step).length === 0) {
         throw new BedrockError('Could not create authorization request.', {
           name: 'DataError',
@@ -749,7 +749,7 @@ async function _getAuthorizationRequest({req}) {
           authorizationRequest.client_id = client_id;
         } else {
           authorizationRequest.client_id =
-            `${exchanger.id}/exchanges/${exchange.id}` +
+            `${workflow.id}/exchanges/${exchange.id}` +
             '/openid/client/authorization/response';
         }
         if(client_id_scheme) {
@@ -792,7 +792,7 @@ async function _getAuthorizationRequest({req}) {
     if(updateExchange) {
       exchange.sequence++;
       try {
-        await exchanges.update({exchangerId: exchanger.id, exchange});
+        await exchanges.update({workflowId: workflow.id, exchange});
       } catch(e) {
         if(e.name !== 'InvalidStateError') {
           // unrecoverable error
@@ -800,7 +800,7 @@ async function _getAuthorizationRequest({req}) {
         }
         // get exchange and loop to try again on `InvalidStateError`
         const record = await exchanges.get(
-          {exchangerId: exchanger.id, id: exchange.id});
+          {workflowId: workflow.id, id: exchange.id});
         ({exchange} = record);
         continue;
       }
@@ -837,7 +837,7 @@ function _matchCredentialRequest(a, b) {
 async function _processAuthorizationResponse({
   req, presentation, presentationSubmission
 }) {
-  const {config: exchanger} = req.serviceObject;
+  const {config: workflow} = req.serviceObject;
   const exchangeRecord = await req.getExchange();
   let {exchange} = exchangeRecord;
 
@@ -850,7 +850,7 @@ async function _processAuthorizationResponse({
   const {verifiablePresentationRequest} = await oid4vp.toVpr(
     {authorizationRequest});
   const {verificationMethod} = await verify({
-    exchanger,
+    workflow,
     verifiablePresentationRequest,
     presentation,
     expectedChallenge: authorizationRequest.nonce
@@ -878,17 +878,17 @@ async function _processAuthorizationResponse({
   exchange.sequence++;
 
   // if there is something to issue, update exchange, do not complete it
-  const {credentialTemplates = []} = exchanger;
+  const {credentialTemplates = []} = workflow;
   if(credentialTemplates?.length > 0 &&
     (exchange.state === 'pending' || exchange.state === 'active')) {
     // ensure exchange state is set to `active` (will be rejected as a
     // conflict if the state in database at update time isn't `pending` or
     // `active`)
     exchange.state = 'active';
-    await exchanges.update({exchangerId: exchanger.id, exchange});
+    await exchanges.update({workflowId: workflow.id, exchange});
   } else {
     // mark exchange complete
-    await exchanges.complete({exchangerId: exchanger.id, exchange});
+    await exchanges.complete({workflowId: workflow.id, exchange});
   }
 
   const result = {};

--- a/lib/vcapi.js
+++ b/lib/vcapi.js
@@ -13,7 +13,7 @@ const {util: {BedrockError}} = bedrock;
 
 const MAXIMUM_STEPS = 100;
 
-export async function processExchange({req, res, exchanger, exchange}) {
+export async function processExchange({req, res, workflow, exchange}) {
   // get any `verifiablePresentation` from the body...
   let receivedPresentation = req?.body?.verifiablePresentation;
 
@@ -35,12 +35,12 @@ export async function processExchange({req, res, exchanger, exchange}) {
     }
 
     // get current step details
-    step = exchanger.steps[currentStep];
+    step = workflow.steps[currentStep];
     if(step.stepTemplate) {
       // generate step from the template; assume the template type is
       // `jsonata` per the JSON schema
       step = await evaluateTemplate(
-        {exchanger, exchange, typedTemplate: step.stepTemplate});
+        {workflow, exchange, typedTemplate: step.stepTemplate});
       if(Object.keys(step).length === 0) {
         throw new BedrockError('Empty step detected.', {
           name: 'DataError',
@@ -61,7 +61,7 @@ export async function processExchange({req, res, exchanger, exchange}) {
     // be in the request
     if(step.verifiablePresentationRequest) {
       const {createChallenge} = step;
-      const isInitialStep = exchange.step === exchanger.initialStep;
+      const isInitialStep = exchange.step === workflow.initialStep;
 
       // if no presentation was received in the body...
       if(!receivedPresentation) {
@@ -78,7 +78,7 @@ export async function processExchange({req, res, exchanger, exchange}) {
             challenge = exchange.id;
           } else {
             // generate a new challenge using verifier API
-            ({challenge} = await _createChallenge({exchanger}));
+            ({challenge} = await _createChallenge({workflow}));
           }
           verifiablePresentationRequest.challenge = challenge;
         }
@@ -88,7 +88,7 @@ export async function processExchange({req, res, exchanger, exchange}) {
         if(exchange.state === 'pending') {
           exchange.state = 'active';
           exchange.sequence++;
-          exchanges.update({exchangerId: exchanger.id, exchange}).catch(
+          exchanges.update({workflowId: workflow.id, exchange}).catch(
             error => logger.error(
               'Could not mark exchange active: ' + error.message, {error}));
         }
@@ -98,7 +98,7 @@ export async function processExchange({req, res, exchanger, exchange}) {
       // verify the received VP
       const expectedChallenge = isInitialStep ? exchange.id : undefined;
       const {verificationMethod} = await verify({
-        exchanger,
+        workflow,
         verifiablePresentationRequest: step.verifiablePresentationRequest,
         presentation: receivedPresentation, expectedChallenge
       });
@@ -132,7 +132,7 @@ export async function processExchange({req, res, exchanger, exchange}) {
         exchange.state = 'active';
       }
       exchange.sequence++;
-      await exchanges.update({exchangerId: exchanger.id, exchange});
+      await exchanges.update({workflowId: workflow.id, exchange});
 
       // FIXME: there may be VCs to issue during this step, do so before
       // sending the VPR above
@@ -148,14 +148,14 @@ export async function processExchange({req, res, exchanger, exchange}) {
 
   // mark exchange complete
   exchange.sequence++;
-  await exchanges.complete({exchangerId: exchanger.id, exchange});
+  await exchanges.complete({workflowId: workflow.id, exchange});
 
   // FIXME: decide what the best recovery path is if delivery fails (but no
   // replay attack detected) after exchange has been marked complete
 
   // issue any VCs; may return an empty result if the step defines no
   // VCs to issue
-  const result = await issue({exchanger, exchange});
+  const result = await issue({workflow, exchange});
 
   // if last `step` has a redirect URL, include it in the response
   if(step?.redirectUrl) {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import {importJWK, jwtVerify} from 'jose';
@@ -11,9 +11,9 @@ import {getZcapClient} from './helpers.js';
 
 const {util: {BedrockError}} = bedrock;
 
-export async function createChallenge({exchanger} = {}) {
+export async function createChallenge({workflow} = {}) {
   // create zcap client for creating challenges
-  const {zcapClient, zcaps} = await getZcapClient({exchanger});
+  const {zcapClient, zcaps} = await getZcapClient({workflow});
 
   // create challenge
   const capability = zcaps.createChallenge;
@@ -22,10 +22,10 @@ export async function createChallenge({exchanger} = {}) {
 }
 
 export async function verify({
-  exchanger, verifiablePresentationRequest, presentation, expectedChallenge
+  workflow, verifiablePresentationRequest, presentation, expectedChallenge
 } = {}) {
   // create zcap client for verifying
-  const {zcapClient, zcaps} = await getZcapClient({exchanger});
+  const {zcapClient, zcaps} = await getZcapClient({workflow});
 
   // verify presentation
   const checks = ['proof'];
@@ -35,7 +35,7 @@ export async function verify({
   }
   const capability = zcaps.verifyPresentation;
   const domain = verifiablePresentationRequest.domain ??
-    new URL(exchanger.id).origin;
+    new URL(workflow.id).origin;
   const result = await zcapClient.write({
     capability,
     json: {
@@ -63,7 +63,7 @@ export async function verify({
   return {verified, challengeUses, verificationMethod};
 }
 
-export async function verifyDidProofJwt({exchanger, exchange, jwt} = {}) {
+export async function verifyDidProofJwt({workflow, exchange, jwt} = {}) {
   // optional oauth2 options
   const {oauth2} = exchange.openId;
   const {maxClockSkew} = oauth2;
@@ -71,7 +71,7 @@ export async function verifyDidProofJwt({exchanger, exchange, jwt} = {}) {
   // audience is always the `exchangeId` and cannot be configured; this
   // prevents attacks where access tokens could otherwise be generated
   // if the AS keys were compromised; the `exchangeId` must also be known
-  const exchangeId = `${exchanger.id}/exchanges/${exchange.id}`;
+  const exchangeId = `${workflow.id}/exchanges/${exchange.id}`;
   const audience = exchangeId;
 
   let issuer;

--- a/schemas/bedrock-vc-workflow.js
+++ b/schemas/bedrock-vc-workflow.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2022-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import {schemas} from '@bedrock/validation';
 

--- a/test/mocha/10-provision.js
+++ b/test/mocha/10-provision.js
@@ -10,12 +10,12 @@ import {mockData} from './mock.data.js';
 
 describe('provision', () => {
   let capabilityAgent;
-  let exchangerIssueZcap;
-  let exchangerCredentialStatusZcap;
-  let exchangerVerifyPresentationZcap;
+  let workflowIssueZcap;
+  let workflowCredentialStatusZcap;
+  let workflowVerifyPresentationZcap;
   beforeEach(async () => {
     ({
-      exchangerIssueZcap, exchangerVerifyPresentationZcap, capabilityAgent
+      workflowIssueZcap, workflowVerifyPresentationZcap, capabilityAgent
     } = await helpers.provisionDependencies());
   });
 
@@ -24,7 +24,7 @@ describe('provision', () => {
       let err;
       let result;
       try {
-        result = await helpers.createExchangerConfig({
+        result = await helpers.createWorkflowConfig({
           capabilityAgent, zcaps: {invalid: ''}
         });
       } catch(e) {
@@ -41,7 +41,7 @@ describe('provision', () => {
       let err;
       let result;
       try {
-        result = await helpers.createExchangerConfig({capabilityAgent});
+        result = await helpers.createWorkflowConfig({capabilityAgent});
       } catch(e) {
         err = e;
       }
@@ -59,9 +59,9 @@ describe('provision', () => {
       let result;
       try {
         const localId = await helpers.generateRandom();
-        result = await helpers.createExchangerConfig({
+        result = await helpers.createWorkflowConfig({
           capabilityAgent, configOptions: {
-            id: `${mockData.baseUrl}/exchangers/${localId}`
+            id: `${mockData.baseUrl}/workflows/${localId}`
           }
         });
       } catch(e) {
@@ -81,9 +81,9 @@ describe('provision', () => {
       let result;
       try {
         const zcaps = {
-          issue: exchangerIssueZcap
+          issue: workflowIssueZcap
         };
-        result = await helpers.createExchangerConfig({capabilityAgent, zcaps});
+        result = await helpers.createWorkflowConfig({capabilityAgent, zcaps});
       } catch(e) {
         err = e;
       }
@@ -101,11 +101,11 @@ describe('provision', () => {
       let result;
       try {
         const zcaps = {
-          issue: exchangerIssueZcap,
-          credentialStatus: exchangerCredentialStatusZcap,
-          verifyPresentation: exchangerVerifyPresentationZcap
+          issue: workflowIssueZcap,
+          credentialStatus: workflowCredentialStatusZcap,
+          verifyPresentation: workflowVerifyPresentationZcap
         };
-        result = await helpers.createExchangerConfig({capabilityAgent, zcaps});
+        result = await helpers.createWorkflowConfig({capabilityAgent, zcaps});
       } catch(e) {
         err = e;
       }
@@ -123,15 +123,15 @@ describe('provision', () => {
       let result;
       try {
         const zcaps = {
-          issue: exchangerIssueZcap,
-          credentialStatus: exchangerCredentialStatusZcap,
-          verifyPresentation: exchangerVerifyPresentationZcap
+          issue: workflowIssueZcap,
+          credentialStatus: workflowCredentialStatusZcap,
+          verifyPresentation: workflowVerifyPresentationZcap
         };
         const credentialTemplates = [{
           type: 'jsonata',
           template: '{}'
         }];
-        result = await helpers.createExchangerConfig(
+        result = await helpers.createWorkflowConfig(
           {capabilityAgent, zcaps, credentialTemplates});
       } catch(e) {
         err = e;
@@ -154,7 +154,7 @@ describe('provision', () => {
           type: 'jsonata',
           template: '{}'
         }];
-        result = await helpers.createExchangerConfig({
+        result = await helpers.createWorkflowConfig({
           capabilityAgent, credentialTemplates
         });
       } catch(e) {
@@ -174,17 +174,17 @@ describe('provision', () => {
       let result;
       try {
         // create config (should pass)
-        result = await helpers.createExchangerConfig({
+        result = await helpers.createWorkflowConfig({
           capabilityAgent, configOptions: {
-            id: `${mockData.baseUrl}/exchangers/z1A183gxYRXYFUnHUXsS7KVmA`
+            id: `${mockData.baseUrl}/workflows/z1A183gxYRXYFUnHUXsS7KVmA`
           }
         });
         should.exist(result);
         // try to create duplicate (should throw)
         result = undefined;
-        result = await helpers.createExchangerConfig({
+        result = await helpers.createWorkflowConfig({
           capabilityAgent, configOptions: {
-            id: `${mockData.baseUrl}/exchangers/z1A183gxYRXYFUnHUXsS7KVmA`
+            id: `${mockData.baseUrl}/workflows/z1A183gxYRXYFUnHUXsS7KVmA`
           }
         });
       } catch(e) {
@@ -201,9 +201,9 @@ describe('provision', () => {
       let err;
       let result;
       try {
-        result = await helpers.createExchangerConfig({
+        result = await helpers.createWorkflowConfig({
           capabilityAgent, configOptions: {
-            id: `${mockData.baseUrl}/exchangers/foo`
+            id: `${mockData.baseUrl}/workflows/foo`
           }
         });
       } catch(e) {
@@ -224,7 +224,7 @@ describe('provision', () => {
       let err;
       let result;
       try {
-        result = await helpers.createExchangerConfig(
+        result = await helpers.createWorkflowConfig(
           {capabilityAgent, ipAllowList});
       } catch(e) {
         err = e;
@@ -246,7 +246,7 @@ describe('provision', () => {
       let err;
       let result;
       try {
-        result = await helpers.createExchangerConfig(
+        result = await helpers.createWorkflowConfig(
           {capabilityAgent, ipAllowList});
       } catch(e) {
         err = e;
@@ -266,7 +266,7 @@ describe('provision', () => {
       let err;
       let result;
       try {
-        result = await helpers.createExchangerConfig(
+        result = await helpers.createWorkflowConfig(
           {capabilityAgent, ipAllowList});
       } catch(e) {
         err = e;
@@ -280,7 +280,7 @@ describe('provision', () => {
       error.details.path.should.equal('.ipAllowList');
     });
     it('throws error on no "sequence"', async () => {
-      const url = `${bedrock.config.server.baseUri}/exchangers`;
+      const url = `${bedrock.config.server.baseUri}/workflows`;
       const config = {
         controller: capabilityAgent.id
       };
@@ -303,10 +303,10 @@ describe('provision', () => {
   describe('get config', () => {
     it('gets a config', async () => {
       const zcaps = {
-        issue: exchangerIssueZcap,
-        verifyPresentation: exchangerVerifyPresentationZcap
+        issue: workflowIssueZcap,
+        verifyPresentation: workflowVerifyPresentationZcap
       };
-      const config = await helpers.createExchangerConfig(
+      const config = await helpers.createWorkflowConfig(
         {capabilityAgent, zcaps});
       let err;
       let result;
@@ -324,10 +324,10 @@ describe('provision', () => {
     });
     it('gets a config w/oauth2', async () => {
       const zcaps = {
-        issue: exchangerIssueZcap,
-        verifyPresentation: exchangerVerifyPresentationZcap
+        issue: workflowIssueZcap,
+        verifyPresentation: workflowVerifyPresentationZcap
       };
-      const config = await helpers.createExchangerConfig(
+      const config = await helpers.createWorkflowConfig(
         {capabilityAgent, zcaps, oauth2: true});
       const accessToken = await helpers.getOAuth2AccessToken(
         {configId: config.id, action: 'read', target: '/'});
@@ -348,7 +348,7 @@ describe('provision', () => {
     it('gets a config with ipAllowList', async () => {
       const ipAllowList = ['127.0.0.1/32', '::1/128'];
 
-      const config = await helpers.createExchangerConfig(
+      const config = await helpers.createWorkflowConfig(
         {capabilityAgent, ipAllowList});
       let err;
       let result;
@@ -369,7 +369,7 @@ describe('provision', () => {
     it('returns NotAllowedError for invalid source IP', async () => {
       const ipAllowList = ['8.8.8.8/32'];
 
-      const config = await helpers.createExchangerConfig(
+      const config = await helpers.createWorkflowConfig(
         {capabilityAgent, ipAllowList});
       let err;
       let result;
@@ -395,7 +395,7 @@ describe('provision', () => {
       let result;
       let existingConfig;
       try {
-        existingConfig = result = await helpers.createExchangerConfig(
+        existingConfig = result = await helpers.createWorkflowConfig(
           {capabilityAgent});
       } catch(e) {
         err = e;
@@ -470,7 +470,7 @@ describe('provision', () => {
       let result;
       let existingConfig;
       try {
-        existingConfig = result = await helpers.createExchangerConfig(
+        existingConfig = result = await helpers.createWorkflowConfig(
           {capabilityAgent});
       } catch(e) {
         err = e;
@@ -594,7 +594,7 @@ describe('provision', () => {
       let err;
       let result;
       try {
-        result = await helpers.createExchangerConfig({capabilityAgent});
+        result = await helpers.createWorkflowConfig({capabilityAgent});
       } catch(e) {
         err = e;
       }
@@ -641,7 +641,7 @@ describe('provision', () => {
       let err;
       let result;
       try {
-        result = await helpers.createExchangerConfig({capabilityAgent});
+        result = await helpers.createWorkflowConfig({capabilityAgent});
       } catch(e) {
         err = e;
       }
@@ -686,7 +686,7 @@ describe('provision', () => {
         let result;
         let existingConfig;
         try {
-          existingConfig = result = await helpers.createExchangerConfig(
+          existingConfig = result = await helpers.createWorkflowConfig(
             {capabilityAgent, ipAllowList});
         } catch(e) {
           err = e;
@@ -765,7 +765,7 @@ describe('provision', () => {
         let err;
         let result;
         try {
-          result = await helpers.createExchangerConfig(
+          result = await helpers.createWorkflowConfig(
             {capabilityAgent, ipAllowList});
         } catch(e) {
           err = e;
@@ -805,7 +805,7 @@ describe('provision', () => {
 
   describe('revocations', () => {
     it('throws error with invalid zcap when revoking', async () => {
-      const config = await helpers.createExchangerConfig({capabilityAgent});
+      const config = await helpers.createWorkflowConfig({capabilityAgent});
       const zcap = {
         '@context': ['https://w3id.org/zcap/v1'],
         id: 'urn:uuid:895d985c-8e20-11ec-b82f-10bf48838a41',
@@ -829,7 +829,7 @@ describe('provision', () => {
         'A validation error occured in the \'Delegated ZCAP\' validator.');
     });
     it('revokes a zcap', async () => {
-      const config = await helpers.createExchangerConfig({capabilityAgent});
+      const config = await helpers.createWorkflowConfig({capabilityAgent});
 
       const capabilityAgent2 = await CapabilityAgent.fromSecret(
         {secret: 's2', handle: 'h2'});

--- a/test/mocha/20-vcapi.js
+++ b/test/mocha/20-vcapi.js
@@ -15,33 +15,33 @@ const {
 
 describe('exchange w/ VC-API delivery', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: credentialTemplate
     }];
-    const exchangerConfig = await helpers.createExchangerConfig(
+    const workflowConfig = await helpers.createWorkflowConfig(
       {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -63,8 +63,8 @@ describe('exchange w/ VC-API delivery', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     const chapiRequest = {
@@ -125,8 +125,8 @@ describe('exchange w/ VC-API delivery', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     // exchange state should be pending
@@ -147,10 +147,10 @@ describe('exchange w/ VC-API delivery', () => {
     {
       let err;
       try {
-        const exchangerId = exchangeId.slice(
+        const workflowId = exchangeId.slice(
           0, exchangeId.lastIndexOf('/exchanges/'));
         const accessToken = await helpers.getOAuth2AccessToken(
-          {configId: exchangerId, action: 'read', target: '/'});
+          {configId: workflowId, action: 'read', target: '/'});
         const {exchange} = await helpers.getExchange(
           {id: exchangeId, accessToken});
         should.exist(exchange?.state);
@@ -242,33 +242,33 @@ describe('exchange w/ VC-API delivery', () => {
 describe('exchange w/ VC-API delivery using credential request ' +
   'template', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: credentialRequestTemplate
     }];
-    const exchangerConfig = await helpers.createExchangerConfig(
+    const workflowConfig = await helpers.createWorkflowConfig(
       {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -290,8 +290,8 @@ describe('exchange w/ VC-API delivery using credential request ' +
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     const chapiRequest = {
@@ -335,33 +335,33 @@ describe('exchange w/ VC-API delivery using credential request ' +
 
 describe('exchange w/ VC-API delivery using prc template', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: prcCredentialTemplate
     }];
-    const exchangerConfig = await helpers.createExchangerConfig(
+    const workflowConfig = await helpers.createWorkflowConfig(
       {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -383,8 +383,8 @@ describe('exchange w/ VC-API delivery using prc template', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
     const chapiRequest = {
       VerifiablePresentation: {
@@ -436,33 +436,33 @@ describe('exchange w/ VC-API delivery using prc template', () => {
 describe('exchange w/ VC-API delivery using generic credential request ' +
   'template', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: genericCredentialRequestTemplate
     }];
-    const exchangerConfig = await helpers.createExchangerConfig(
+    const workflowConfig = await helpers.createWorkflowConfig(
       {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -484,8 +484,8 @@ describe('exchange w/ VC-API delivery using generic credential request ' +
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap,
+      workflowId,
+      workflowRootZcap,
       variables: {
         credentialId,
         credentialRequest: `{
@@ -562,33 +562,33 @@ describe('exchange w/ VC-API delivery using generic credential request ' +
 
 describe('exchange w/ VC-API delivery using generic template', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: genericCredentialTemplate
     }];
-    const exchangerConfig = await helpers.createExchangerConfig(
+    const workflowConfig = await helpers.createWorkflowConfig(
       {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -610,8 +610,8 @@ describe('exchange w/ VC-API delivery using generic template', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap,
+      workflowId,
+      workflowRootZcap,
       variables: {
         credentialId,
         vc: `{

--- a/test/mocha/21-vcapi-did-authn.js
+++ b/test/mocha/21-vcapi-did-authn.js
@@ -13,30 +13,30 @@ const {
 
 describe('exchange w/ VC-API delivery + DID authn', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: didAuthnCredentialTemplate
     }];
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -52,12 +52,12 @@ describe('exchange w/ VC-API delivery + DID authn', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
       oauth2: true
     });
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass when sending VP in single call', async () => {
@@ -79,8 +79,8 @@ describe('exchange w/ VC-API delivery + DID authn', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
       // FIXME: add test with a `requiredDid` -- any presented VPs must include
       // DID Authn with a DID that matches the `requiredDid` value -- however,
       // this might be generalized into some other kind of VPR satisfaction
@@ -156,8 +156,8 @@ describe('exchange w/ VC-API delivery + DID authn', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     // exchange state should be pending
@@ -261,30 +261,30 @@ describe('exchange w/ VC-API delivery + DID authn', () => {
 
 describe('exchange w/ VC-API delivery + DID authn + generic template', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: genericCredentialTemplate
     }];
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -300,12 +300,12 @@ describe('exchange w/ VC-API delivery + DID authn + generic template', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
       oauth2: true
     });
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -327,8 +327,8 @@ describe('exchange w/ VC-API delivery + DID authn + generic template', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap,
+      workflowId,
+      workflowRootZcap,
       variables: {
         credentialId,
         vc: `{
@@ -410,22 +410,22 @@ describe('exchange w/ VC-API delivery + DID authn + generic template', () => {
 
 describe('exchange w/ VC-API presentation + templated DID authn', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -444,11 +444,11 @@ describe('exchange w/ VC-API presentation + templated DID authn', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, steps, initialStep
     });
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -466,8 +466,8 @@ describe('exchange w/ VC-API presentation + templated DID authn', () => {
       }
     };
     const {id: exchangeId} = await helpers.createExchange({
-      url: `${exchangerId}/exchanges`,
-      capabilityAgent, capability: exchangerRootZcap, exchange
+      url: `${workflowId}/exchanges`,
+      capabilityAgent, capability: workflowRootZcap, exchange
     });
 
     // post to exchange URL to get expected VPR
@@ -523,22 +523,22 @@ describe('exchange w/ VC-API presentation + templated DID authn', () => {
 
 describe('exchange w/ VC-API presentation + templated VPR', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -554,11 +554,11 @@ describe('exchange w/ VC-API presentation + templated VPR', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, steps, initialStep
     });
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -578,8 +578,8 @@ describe('exchange w/ VC-API presentation + templated VPR', () => {
       }
     };
     const {id: exchangeId} = await helpers.createExchange({
-      url: `${exchangerId}/exchanges`,
-      capabilityAgent, capability: exchangerRootZcap, exchange
+      url: `${workflowId}/exchanges`,
+      capabilityAgent, capability: workflowRootZcap, exchange
     });
 
     // post to exchange URL to get expected VPR

--- a/test/mocha/22-vcapi-verify-vc-issue-vc.js
+++ b/test/mocha/22-vcapi-verify-vc-issue-vc.js
@@ -21,25 +21,25 @@ describe('exchange w/ VC-API delivery + DID authn + VC request', () => {
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: didAuthnCredentialTemplate
     }];
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -55,11 +55,11 @@ describe('exchange w/ VC-API delivery + DID authn + VC request', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
       oauth2: true
     });
-    const workflowId = exchangerConfig.id;
+    const workflowId = workflowConfig.id;
     const workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
 
     // use workflow to provision verifiable credential
@@ -72,8 +72,8 @@ describe('exchange w/ VC-API delivery + DID authn + VC request', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId: workflowId,
-      exchangerRootZcap: workflowRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     // generate VP
@@ -97,25 +97,25 @@ describe('exchange w/ VC-API delivery + DID authn + VC request', () => {
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: didAuthnCredentialTemplate
     }];
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step, additionally require VC that was issued from
       // workflow 1
@@ -144,11 +144,11 @@ describe('exchange w/ VC-API delivery + DID authn + VC request', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
       oauth2: true
     });
-    workflowId = exchangerConfig.id;
+    workflowId = workflowConfig.id;
     workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
@@ -162,8 +162,8 @@ describe('exchange w/ VC-API delivery + DID authn + VC request', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId: workflowId,
-      exchangerRootZcap: workflowRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     // generate VP
@@ -217,8 +217,8 @@ describe('exchange w/ VC-API delivery + DID authn + VC request', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId: workflowId,
-      exchangerRootZcap: workflowRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     // post empty body to get VPR in response

--- a/test/mocha/30-oid4vci.js
+++ b/test/mocha/30-oid4vci.js
@@ -11,33 +11,33 @@ const {credentialTemplate} = mockData;
 
 describe('exchange w/OID4VCI delivery', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: credentialTemplate
     }];
-    const exchangerConfig = await helpers.createExchangerConfig(
+    const workflowConfig = await helpers.createWorkflowConfig(
       {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass w/ pre-authorized code flow', async () => {
@@ -60,8 +60,8 @@ describe('exchange w/OID4VCI delivery', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
     const chapiRequest = {OID4VC: offerUrl};
     // CHAPI could potentially be used to deliver the URL to a native app
@@ -130,8 +130,8 @@ describe('exchange w/OID4VCI delivery', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap,
+      workflowId,
+      workflowRootZcap,
       openIdKeyPair
     });
 
@@ -188,8 +188,8 @@ describe('exchange w/OID4VCI delivery', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap,
+      workflowId,
+      workflowRootZcap,
       openIdKeyPair
     });
 
@@ -251,8 +251,8 @@ describe('exchange w/OID4VCI delivery', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
     const chapiRequest = {OID4VC: issuanceUrl};
     // CHAPI could potentially be used to deliver the URL to a native app

--- a/test/mocha/31-oid4vci-did-authn.js
+++ b/test/mocha/31-oid4vci-did-authn.js
@@ -11,30 +11,30 @@ const {baseUrl, didAuthnCredentialTemplate} = mockData;
 
 describe('exchange w/OID4VCI delivery + DID authn', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: didAuthnCredentialTemplate
     }];
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -55,12 +55,12 @@ describe('exchange w/OID4VCI delivery + DID authn', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
       oauth2: true
     });
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass w/ pre-authorized code flow', async () => {
@@ -83,8 +83,8 @@ describe('exchange w/OID4VCI delivery + DID authn', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
       // FIXME: add test with a `requiredDid` -- any presented VPs must include
       // DID Authn with a DID that matches the `requiredDid` value -- however,
       // this might be generalized into some other kind of VPR satisfaction

--- a/test/mocha/32-batch-oid4vci.js
+++ b/test/mocha/32-batch-oid4vci.js
@@ -11,24 +11,24 @@ const {credentialTemplate} = mockData;
 
 describe('exchange w/batch OID4VCI delivery', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
@@ -39,10 +39,10 @@ describe('exchange w/batch OID4VCI delivery', () => {
       template: credentialTemplate.replace(
         'credentialId', 'credentialId2')
     }];
-    const exchangerConfig = await helpers.createExchangerConfig(
+    const workflowConfig = await helpers.createWorkflowConfig(
       {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass w/ pre-authorized code flow', async () => {
@@ -72,8 +72,8 @@ describe('exchange w/batch OID4VCI delivery', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
     const chapiRequest = {OID4VC: issuanceUrl};
     // CHAPI could potentially be used to deliver the URL to a native app

--- a/test/mocha/33-batch-oid4vci-did-authn.js
+++ b/test/mocha/33-batch-oid4vci-did-authn.js
@@ -11,24 +11,24 @@ const {baseUrl, didAuthnCredentialTemplate} = mockData;
 
 describe('exchange w/batch OID4VCI delivery + DID authn', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
@@ -39,7 +39,7 @@ describe('exchange w/batch OID4VCI delivery + DID authn', () => {
       template: didAuthnCredentialTemplate.replace(
         'credentialId', 'credentialId2')
     }];
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -60,12 +60,12 @@ describe('exchange w/batch OID4VCI delivery + DID authn', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
       oauth2: true
     });
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass w/ pre-authorized code flow', async () => {
@@ -95,8 +95,8 @@ describe('exchange w/batch OID4VCI delivery + DID authn', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
       // FIXME: add test with a `requiredDid` -- any presented VPs must include
       // DID Authn with a DID that matches the `requiredDid` value -- however,
       // this might be generalized into some other kind of VPR satisfaction

--- a/test/mocha/34-oid4vp.js
+++ b/test/mocha/34-oid4vp.js
@@ -13,22 +13,22 @@ const {getAuthorizationRequest} = oid4vp;
 
 describe('exchange w/ OID4VP presentation w/DID Authn only', () => {
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -41,7 +41,7 @@ describe('exchange w/ OID4VP presentation w/DID Authn only', () => {
             "openId": {
               "createAuthorizationRequest": "authorizationRequest",
               "client_id_scheme": "redirect_uri",
-              "client_id": globals.exchanger.id &
+              "client_id": globals.workflow.id &
                 "/exchanges/" &
                 globals.exchange.id &
                 "/openid/client/authorization/response"
@@ -52,11 +52,11 @@ describe('exchange w/ OID4VP presentation w/DID Authn only', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, steps, initialStep, oauth2: true
     });
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -77,8 +77,8 @@ describe('exchange w/ OID4VP presentation w/DID Authn only', () => {
       }
     };
     const {id: exchangeId} = await helpers.createExchange({
-      url: `${exchangerId}/exchanges`,
-      capabilityAgent, capability: exchangerRootZcap, exchange
+      url: `${workflowId}/exchanges`,
+      capabilityAgent, capability: workflowRootZcap, exchange
     });
 
     // request URI
@@ -186,28 +186,28 @@ describe('exchange w/ OID4VP presentation w/VC', () => {
     const deps = await helpers.provisionDependencies();
     const {
       capabilityAgent,
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
 
-    // create exchanger instance to issue VCs
+    // create workflow instance to issue VCs
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: alumniCredentialTemplate
     }];
-    const exchangerConfig = await helpers.createExchangerConfig(
+    const workflowConfig = await helpers.createWorkflowConfig(
       {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
-    const exchangerId = exchangerConfig.id;
-    const exchangerRootZcap =
-      `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    const workflowId = workflowConfig.id;
+    const workflowRootZcap =
+      `urn:zcap:root:${encodeURIComponent(workflowId)}`;
 
     // create exchange to issue VC
     const credentialId = `urn:uuid:${uuid()}`;
@@ -219,8 +219,8 @@ describe('exchange w/ OID4VP presentation w/VC', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId,
-      exchangerRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     // post empty body and get VP w/VCs in response
@@ -230,22 +230,22 @@ describe('exchange w/ OID4VP presentation w/VC', () => {
   });
 
   let capabilityAgent;
-  let exchangerId;
-  let exchangerRootZcap;
+  let workflowId;
+  let workflowRootZcap;
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       myStep: {
         stepTemplate: {
@@ -261,11 +261,11 @@ describe('exchange w/ OID4VP presentation w/VC', () => {
     };
     // set initial step
     const initialStep = 'myStep';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, steps, initialStep, oauth2: true
     });
-    exchangerId = exchangerConfig.id;
-    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+    workflowId = workflowConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
   it('should pass', async () => {
@@ -301,8 +301,8 @@ describe('exchange w/ OID4VP presentation w/VC', () => {
       }
     };
     const {id: exchangeId} = await helpers.createExchange({
-      url: `${exchangerId}/exchanges`,
-      capabilityAgent, capability: exchangerRootZcap, exchange
+      url: `${workflowId}/exchanges`,
+      capabilityAgent, capability: workflowRootZcap, exchange
     });
     const authzReqUrl = `${exchangeId}/openid/client/authorization/request`;
 

--- a/test/mocha/35-oid4vci-oid4vp.js
+++ b/test/mocha/35-oid4vci-oid4vp.js
@@ -22,25 +22,25 @@ describe('exchange w/OID4VCI delivery + OID4VP VC requirement', () => {
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: didAuthnCredentialTemplate
     }];
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -56,11 +56,11 @@ describe('exchange w/OID4VCI delivery + OID4VP VC requirement', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
       oauth2: true
     });
-    const workflowId = exchangerConfig.id;
+    const workflowId = workflowConfig.id;
     const workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
 
     // use workflow to provision verifiable credential
@@ -73,8 +73,8 @@ describe('exchange w/OID4VCI delivery + OID4VP VC requirement', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId: workflowId,
-      exchangerRootZcap: workflowRootZcap
+      workflowId,
+      workflowRootZcap
     });
 
     // generate VP
@@ -98,25 +98,25 @@ describe('exchange w/OID4VCI delivery + OID4VP VC requirement', () => {
   beforeEach(async () => {
     const deps = await helpers.provisionDependencies();
     const {
-      exchangerIssueZcap,
-      exchangerCredentialStatusZcap,
-      exchangerCreateChallengeZcap,
-      exchangerVerifyPresentationZcap
+      workflowIssueZcap,
+      workflowCredentialStatusZcap,
+      workflowCreateChallengeZcap,
+      workflowVerifyPresentationZcap
     } = deps;
     ({capabilityAgent} = deps);
 
-    // create exchanger instance w/ oauth2-based authz
+    // create workflow instance w/ oauth2-based authz
     const zcaps = {
-      issue: exchangerIssueZcap,
-      credentialStatus: exchangerCredentialStatusZcap,
-      createChallenge: exchangerCreateChallengeZcap,
-      verifyPresentation: exchangerVerifyPresentationZcap
+      issue: workflowIssueZcap,
+      credentialStatus: workflowCredentialStatusZcap,
+      createChallenge: workflowCreateChallengeZcap,
+      verifyPresentation: workflowVerifyPresentationZcap
     };
     const credentialTemplates = [{
       type: 'jsonata',
       template: didAuthnCredentialTemplate
     }];
-    // require semantically-named exchanger steps
+    // require semantically-named workflow steps
     const steps = {
       // DID Authn step
       didAuthn: {
@@ -129,7 +129,7 @@ describe('exchange w/OID4VCI delivery + OID4VP VC requirement', () => {
             "openId": {
               "createAuthorizationRequest": "authorizationRequest",
               "client_id_scheme": "redirect_uri",
-              "client_id": globals.exchanger.id &
+              "client_id": globals.workflow.id &
                 "/exchanges/" &
                 globals.exchange.id &
                 "/openid/client/authorization/response"
@@ -140,11 +140,11 @@ describe('exchange w/OID4VCI delivery + OID4VP VC requirement', () => {
     };
     // set initial step
     const initialStep = 'didAuthn';
-    const exchangerConfig = await helpers.createExchangerConfig({
+    const workflowConfig = await helpers.createWorkflowConfig({
       capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
       oauth2: true
     });
-    workflowId = exchangerConfig.id;
+    workflowId = workflowConfig.id;
     workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
   });
 
@@ -182,8 +182,8 @@ describe('exchange w/OID4VCI delivery + OID4VP VC requirement', () => {
       preAuthorized: true,
       userPinRequired: false,
       capabilityAgent,
-      exchangerId: workflowId,
-      exchangerRootZcap: workflowRootZcap,
+      workflowId,
+      workflowRootZcap,
       variables: {
         credentialId,
         verifiablePresentationRequest: vpr,

--- a/test/mocha/backwards-compatibility/10-provision.js
+++ b/test/mocha/backwards-compatibility/10-provision.js
@@ -1,0 +1,871 @@
+/*!
+ * Copyright (c) 2019-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as bedrock from '@bedrock/core';
+import * as helpers from './helpers.js';
+import {agent} from '@bedrock/https-agent';
+import {CapabilityAgent} from '@digitalbazaar/webkms-client';
+import {httpClient} from '@digitalbazaar/http-client';
+import {mockData} from './mock.data.js';
+
+describe('exchanger backwards-compatibility: ' +
+  'provision', () => {
+  let capabilityAgent;
+  let exchangerIssueZcap;
+  let exchangerCredentialStatusZcap;
+  let exchangerVerifyPresentationZcap;
+  beforeEach(async () => {
+    ({
+      exchangerIssueZcap, exchangerVerifyPresentationZcap, capabilityAgent
+    } = await helpers.provisionDependencies());
+  });
+
+  describe('create config', () => {
+    it('throws error on bad zcaps', async () => {
+      let err;
+      let result;
+      try {
+        result = await helpers.createExchangerConfig({
+          capabilityAgent, zcaps: {invalid: ''}
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.data.details.errors.should.have.length(1);
+      const [error] = err.data.details.errors;
+      error.name.should.equal('ValidationError');
+      error.message.should.contain('should NOT have additional properties');
+    });
+    it('creates a config with no zcaps', async () => {
+      let err;
+      let result;
+      try {
+        result = await helpers.createExchangerConfig({capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'controller', 'id', 'sequence', 'meterId'
+      ]);
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.controller.should.equal(capabilityAgentId);
+    });
+    it('creates a config with a client-chosen ID', async () => {
+      let err;
+      let result;
+      try {
+        const localId = await helpers.generateRandom();
+        result = await helpers.createExchangerConfig({
+          capabilityAgent, configOptions: {
+            id: `${mockData.baseUrl}/exchangers/${localId}`
+          }
+        });
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'controller', 'id', 'sequence', 'meterId'
+      ]);
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.controller.should.equal(capabilityAgentId);
+    });
+    it('creates a config with only an issue zcap', async () => {
+      let err;
+      let result;
+      try {
+        const zcaps = {
+          issue: exchangerIssueZcap
+        };
+        result = await helpers.createExchangerConfig({capabilityAgent, zcaps});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'controller', 'id', 'sequence', 'meterId', 'zcaps'
+      ]);
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.controller.should.equal(capabilityAgentId);
+    });
+    it('creates a config with issue, status, and verify zcaps', async () => {
+      let err;
+      let result;
+      try {
+        const zcaps = {
+          issue: exchangerIssueZcap,
+          credentialStatus: exchangerCredentialStatusZcap,
+          verifyPresentation: exchangerVerifyPresentationZcap
+        };
+        result = await helpers.createExchangerConfig({capabilityAgent, zcaps});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'controller', 'id', 'sequence', 'meterId', 'zcaps'
+      ]);
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.controller.should.equal(capabilityAgentId);
+    });
+    it('creates a config with credential templates', async () => {
+      let err;
+      let result;
+      try {
+        const zcaps = {
+          issue: exchangerIssueZcap,
+          credentialStatus: exchangerCredentialStatusZcap,
+          verifyPresentation: exchangerVerifyPresentationZcap
+        };
+        const credentialTemplates = [{
+          type: 'jsonata',
+          template: '{}'
+        }];
+        result = await helpers.createExchangerConfig(
+          {capabilityAgent, zcaps, credentialTemplates});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'controller', 'id', 'sequence', 'meterId', 'zcaps',
+        'credentialTemplates'
+      ]);
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.controller.should.equal(capabilityAgentId);
+    });
+    it('throws with credential templates and no issue zcap', async () => {
+      let err;
+      let result;
+      try {
+        const credentialTemplates = [{
+          type: 'jsonata',
+          template: '{}'
+        }];
+        result = await helpers.createExchangerConfig({
+          capabilityAgent, credentialTemplates
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      should.exist(err.data);
+      err.data.name.should.equal('DataError');
+      const {message} = err.data.details.cause;
+      message.should.contain(
+        'A capability to issue credentials is required when credential ' +
+        'templates are provided.');
+    });
+    it('throws if duplicate client-chosen ID is used', async () => {
+      let err;
+      let result;
+      try {
+        // create config (should pass)
+        result = await helpers.createExchangerConfig({
+          capabilityAgent, configOptions: {
+            id: `${mockData.baseUrl}/exchangers/z1A183gxYRXYFUnHUXsS7KVmA`
+          }
+        });
+        should.exist(result);
+        // try to create duplicate (should throw)
+        result = undefined;
+        result = await helpers.createExchangerConfig({
+          capabilityAgent, configOptions: {
+            id: `${mockData.baseUrl}/exchangers/z1A183gxYRXYFUnHUXsS7KVmA`
+          }
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      should.exist(err.data);
+      err.status.should.equal(409);
+      err.data.name.should.equal('DuplicateError');
+      err.data.message.should.contain('Duplicate configuration');
+    });
+    it('throws if invalid client-chosen ID is used', async () => {
+      let err;
+      let result;
+      try {
+        result = await helpers.createExchangerConfig({
+          capabilityAgent, configOptions: {
+            id: `${mockData.baseUrl}/exchangers/foo`
+          }
+        });
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      should.exist(err.data);
+      err.status.should.equal(400);
+      err.data.name.should.equal('DataError');
+      err.data.message.should.contain('Configuration validation failed');
+      err.data.details.cause.message.should.contain(
+        'Invalid client-provided configuration ID');
+    });
+    it('creates a config including proper ipAllowList', async () => {
+      const ipAllowList = ['127.0.0.1/32', '::1/128'];
+
+      let err;
+      let result;
+      try {
+        result = await helpers.createExchangerConfig(
+          {capabilityAgent, ipAllowList});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'controller', 'id', 'ipAllowList', 'sequence', 'meterId'
+      ]);
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.controller.should.equal(capabilityAgentId);
+      result.ipAllowList.should.eql(ipAllowList);
+    });
+    it('throws error on invalid ipAllowList', async () => {
+      // this is not a valid CIDR
+      const ipAllowList = ['127.0.0.1/33'];
+
+      let err;
+      let result;
+      try {
+        result = await helpers.createExchangerConfig(
+          {capabilityAgent, ipAllowList});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.data.details.errors.should.have.length(1);
+      const [error] = err.data.details.errors;
+      error.name.should.equal('ValidationError');
+      error.message.should.contain('should match pattern');
+      error.details.path.should.equal('.ipAllowList[0]');
+    });
+    it('throws error on invalid ipAllowList', async () => {
+      // an empty allow list is invalid
+      const ipAllowList = [];
+
+      let err;
+      let result;
+      try {
+        result = await helpers.createExchangerConfig(
+          {capabilityAgent, ipAllowList});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.data.details.errors.should.have.length(1);
+      const [error] = err.data.details.errors;
+      error.name.should.equal('ValidationError');
+      error.message.should.contain('should NOT have fewer than 1 items');
+      error.details.path.should.equal('.ipAllowList');
+    });
+    it('throws error on no "sequence"', async () => {
+      const url = `${bedrock.config.server.baseUri}/exchangers`;
+      const config = {
+        controller: capabilityAgent.id
+      };
+
+      let err;
+      let result;
+      try {
+        result = await httpClient.post(url, {agent, json: config});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.data.type.should.equal('ValidationError');
+      err.data.message.should.equal(
+        'A validation error occured in the \'createConfigBody\' validator.');
+    });
+  });
+
+  describe('get config', () => {
+    it('gets a config', async () => {
+      const zcaps = {
+        issue: exchangerIssueZcap,
+        verifyPresentation: exchangerVerifyPresentationZcap
+      };
+      const config = await helpers.createExchangerConfig(
+        {capabilityAgent, zcaps});
+      let err;
+      let result;
+      try {
+        result = await helpers.getConfig({id: config.id, capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'controller', 'id', 'sequence', 'meterId', 'zcaps'
+      ]);
+      result.id.should.equal(config.id);
+    });
+    it('gets a config w/oauth2', async () => {
+      const zcaps = {
+        issue: exchangerIssueZcap,
+        verifyPresentation: exchangerVerifyPresentationZcap
+      };
+      const config = await helpers.createExchangerConfig(
+        {capabilityAgent, zcaps, oauth2: true});
+      const accessToken = await helpers.getOAuth2AccessToken(
+        {configId: config.id, action: 'read', target: '/'});
+      let err;
+      let result;
+      try {
+        result = await helpers.getConfig({id: config.id, accessToken});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'authorization', 'controller', 'id', 'sequence', 'meterId', 'zcaps'
+      ]);
+      result.id.should.equal(config.id);
+    });
+    it('gets a config with ipAllowList', async () => {
+      const ipAllowList = ['127.0.0.1/32', '::1/128'];
+
+      const config = await helpers.createExchangerConfig(
+        {capabilityAgent, ipAllowList});
+      let err;
+      let result;
+      try {
+        result = await helpers.getConfig({id: config.id, capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.keys([
+        'controller', 'id', 'ipAllowList', 'sequence', 'meterId'
+      ]);
+      result.should.have.property('id');
+      result.id.should.equal(config.id);
+      result.ipAllowList.should.eql(ipAllowList);
+    });
+    it('returns NotAllowedError for invalid source IP', async () => {
+      const ipAllowList = ['8.8.8.8/32'];
+
+      const config = await helpers.createExchangerConfig(
+        {capabilityAgent, ipAllowList});
+      let err;
+      let result;
+      try {
+        result = await helpers.getConfig({id: config.id, capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      should.not.exist(result);
+      should.exist(err);
+      err.status.should.equal(403);
+      err.data.type.should.equal('NotAllowedError');
+    });
+  }); // get config
+
+  describe('update config', () => {
+    it('updates a config', async () => {
+      // create new capability agent to change config `controller` to
+      const capabilityAgent2 = await CapabilityAgent.fromSecret(
+        {secret: 's2', handle: 'h2'});
+
+      let err;
+      let result;
+      let existingConfig;
+      try {
+        existingConfig = result = await helpers.createExchangerConfig(
+          {capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.property('id');
+      result.should.have.property('sequence');
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.should.have.property('controller');
+      result.controller.should.equal(capabilityAgentId);
+
+      // this update does not change the `meterId`
+      const {id: url} = result;
+      const newConfig = {
+        ...existingConfig,
+        controller: capabilityAgent2.id,
+        sequence: 1
+      };
+
+      err = null;
+      result = null;
+      try {
+        const zcapClient = helpers.createZcapClient({capabilityAgent});
+        result = await zcapClient.write({url, json: newConfig});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result.data);
+      result.status.should.equal(200);
+      result.data.should.have.keys([
+        'id', 'controller', 'sequence', 'meterId'
+      ]);
+      const expectedConfig = {
+        ...existingConfig,
+        ...newConfig
+      };
+      result.data.should.eql(expectedConfig);
+
+      // should fail to retrieve the config now that controller
+      // has changed
+      err = null;
+      result = null;
+      try {
+        result = await helpers.getConfig(
+          {id: newConfig.id, capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.status.should.equal(403);
+      err.data.type.should.equal('NotAllowedError');
+
+      // retrieve the config to confirm update was effective
+      err = null;
+      result = null;
+      try {
+        result = await helpers.getConfig(
+          {id: newConfig.id, capabilityAgent: capabilityAgent2});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.eql(expectedConfig);
+    });
+    it('updates a config enabling oauth2', async () => {
+      let err;
+      let result;
+      let existingConfig;
+      try {
+        existingConfig = result = await helpers.createExchangerConfig(
+          {capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.property('id');
+      result.should.have.property('sequence');
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.should.have.property('controller');
+      result.controller.should.equal(capabilityAgentId);
+
+      // should fail to retrieve the config since `oauth2` is not yet
+      // enabled
+      const accessToken = await helpers.getOAuth2AccessToken(
+        {configId: existingConfig.id, action: 'read', target: '/'});
+      err = null;
+      result = null;
+      try {
+        result = await helpers.getConfig(
+          {id: existingConfig.id, accessToken});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.status.should.equal(403);
+      err.data.type.should.equal('NotAllowedError');
+
+      // this update adds `oauth2` authz config
+      const {baseUri} = bedrock.config.server;
+      let newConfig = {
+        ...existingConfig,
+        sequence: 1,
+        authorization: {
+          oauth2: {
+            issuerConfigUrl: `${baseUri}${mockData.oauth2IssuerConfigRoute}`
+          }
+        }
+      };
+      err = null;
+      result = null;
+      try {
+        const url = existingConfig.id;
+        const zcapClient = helpers.createZcapClient({capabilityAgent});
+        result = await zcapClient.write({url, json: newConfig});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result.data);
+      result.status.should.equal(200);
+      result.data.should.have.keys([
+        'id', 'controller', 'sequence', 'meterId', 'authorization'
+      ]);
+      let expectedConfig = {
+        ...existingConfig,
+        ...newConfig
+      };
+      result.data.should.eql(expectedConfig);
+
+      // retrieve the config using `oauth2` to confirm update was effective
+      err = null;
+      result = null;
+      try {
+        result = await helpers.getConfig({id: newConfig.id, accessToken});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.eql(expectedConfig);
+
+      // this update removes `oauth2` authz config
+      newConfig = {
+        ...existingConfig,
+        sequence: 2
+      };
+      delete newConfig.authorization;
+      err = null;
+      result = null;
+      try {
+        const url = existingConfig.id;
+        const zcapClient = helpers.createZcapClient({capabilityAgent});
+        result = await zcapClient.write({url, json: newConfig});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result.data);
+      result.status.should.equal(200);
+      result.data.should.have.keys([
+        'id', 'controller', 'sequence', 'meterId'
+      ]);
+      expectedConfig = {
+        ...existingConfig,
+        ...newConfig
+      };
+      result.data.should.eql(expectedConfig);
+
+      // should fail to retrieve the config since `oauth2` is no longer
+      // enabled
+      err = null;
+      result = null;
+      try {
+        result = await helpers.getConfig(
+          {id: existingConfig.id, accessToken});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.status.should.equal(403);
+      err.data.type.should.equal('NotAllowedError');
+    });
+    it('rejects config update for an invalid zcap', async () => {
+      const capabilityAgent2 = await CapabilityAgent.fromSecret(
+        {secret: 's2', handle: 'h2'});
+
+      let err;
+      let result;
+      try {
+        result = await helpers.createExchangerConfig({capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.property('id');
+      result.should.have.property('sequence');
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.should.have.property('controller');
+      result.controller.should.equal(capabilityAgentId);
+
+      const {id: url} = result;
+      const newConfig = {
+        ...result,
+        controller: capabilityAgent2.id,
+        sequence: 1
+      };
+
+      err = null;
+      result = null;
+      try {
+        // the capability invocation here is signed by `capabilityAgent2`
+        // which is not the `controller` of the config
+        const zcapClient = helpers.createZcapClient({
+          capabilityAgent: capabilityAgent2
+        });
+        result = await zcapClient.write({url, json: newConfig});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.status.should.equal(403);
+      err.data.type.should.equal('NotAllowedError');
+      err.data.cause.message.should.contain(
+        'The capability controller does not match the verification method ' +
+        '(or its controller) used to invoke.');
+    });
+    it('rejects config update with an invalid sequence', async () => {
+      const capabilityAgent2 = await CapabilityAgent.fromSecret(
+        {secret: 's2', handle: 'h2'});
+
+      let err;
+      let result;
+      try {
+        result = await helpers.createExchangerConfig({capabilityAgent});
+      } catch(e) {
+        err = e;
+      }
+      assertNoError(err);
+      should.exist(result);
+      result.should.have.property('id');
+      result.should.have.property('sequence');
+      result.sequence.should.equal(0);
+      const {id: capabilityAgentId} = capabilityAgent;
+      result.should.have.property('controller');
+      result.controller.should.equal(capabilityAgentId);
+
+      const {id: url} = result;
+      const newConfig = {
+        ...result,
+        controller: capabilityAgent2.id,
+        // the proper sequence would be 1
+        sequence: 10
+      };
+
+      err = null;
+      result = null;
+      try {
+        const zcapClient = helpers.createZcapClient({capabilityAgent});
+        result = await zcapClient.write({url, json: newConfig});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.status.should.equal(409);
+      err.data.type.should.equal('InvalidStateError');
+    });
+    describe('updates with ipAllowList', () => {
+      it('updates a config with ipAllowList', async () => {
+        const capabilityAgent2 = await CapabilityAgent.fromSecret(
+          {secret: 's2', handle: 'h2'});
+
+        const ipAllowList = ['127.0.0.1/32', '::1/128'];
+
+        let err;
+        let result;
+        let existingConfig;
+        try {
+          existingConfig = result = await helpers.createExchangerConfig(
+            {capabilityAgent, ipAllowList});
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.should.have.property('id');
+        result.should.have.property('sequence');
+        result.sequence.should.equal(0);
+        const {id: capabilityAgentId} = capabilityAgent;
+        result.should.have.property('controller');
+        result.controller.should.equal(capabilityAgentId);
+
+        const {id: url} = result;
+        const newConfig = {
+          ...existingConfig,
+          controller: capabilityAgent2.id,
+          ipAllowList,
+          sequence: 1
+        };
+
+        err = null;
+        result = null;
+        try {
+          const zcapClient = helpers.createZcapClient({capabilityAgent});
+          result = await zcapClient.write({url, json: newConfig});
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result.data);
+        result.status.should.equal(200);
+        result.data.should.have.keys([
+          'id', 'controller', 'sequence', 'meterId', 'ipAllowList'
+        ]);
+        const expectedConfig = {
+          ...existingConfig,
+          ...newConfig
+        };
+        result.data.should.eql(expectedConfig);
+
+        // should fail to retrieve the config now that controller
+        // has changed
+        err = null;
+        result = null;
+        try {
+          result = await helpers.getConfig(
+            {id: newConfig.id, capabilityAgent});
+        } catch(e) {
+          err = e;
+        }
+        should.exist(err);
+        should.not.exist(result);
+        err.status.should.equal(403);
+        err.data.type.should.equal('NotAllowedError');
+
+        // retrieve the config to confirm update was effective
+        err = null;
+        result = null;
+        try {
+          result = await helpers.getConfig(
+            {id: newConfig.id, capabilityAgent: capabilityAgent2});
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.should.eql(expectedConfig);
+      });
+      it('returns NotAllowedError for invalid source IP', async () => {
+        const capabilityAgent2 = await CapabilityAgent.fromSecret(
+          {secret: 's2', handle: 'h2'});
+
+        const ipAllowList = ['8.8.8.8/32'];
+
+        let err;
+        let result;
+        try {
+          result = await helpers.createExchangerConfig(
+            {capabilityAgent, ipAllowList});
+        } catch(e) {
+          err = e;
+        }
+        assertNoError(err);
+        should.exist(result);
+        result.should.have.property('id');
+        result.should.have.property('sequence');
+        result.sequence.should.equal(0);
+        const {id: capabilityAgentId} = capabilityAgent;
+        result.should.have.property('controller');
+        result.controller.should.equal(capabilityAgentId);
+
+        const {id: url} = result;
+        const newConfig = {
+          ...result,
+          controller: capabilityAgent2.id,
+          ipAllowList,
+          sequence: 1
+        };
+
+        err = null;
+        result = null;
+        try {
+          const zcapClient = helpers.createZcapClient({capabilityAgent});
+          result = await zcapClient.write({url, json: newConfig});
+        } catch(e) {
+          err = e;
+        }
+        should.not.exist(result);
+        should.exist(err);
+        err.status.should.equal(403);
+        err.data.type.should.equal('NotAllowedError');
+      });
+    }); // updates with ipAllowList
+  }); // end update config
+
+  describe('revocations', () => {
+    it('throws error with invalid zcap when revoking', async () => {
+      const config = await helpers.createExchangerConfig({capabilityAgent});
+      const zcap = {
+        '@context': ['https://w3id.org/zcap/v1'],
+        id: 'urn:uuid:895d985c-8e20-11ec-b82f-10bf48838a41',
+        proof: {}
+      };
+
+      const url =
+        `${config.id}/zcaps/revocations/${encodeURIComponent(zcap.id)}`;
+
+      let err;
+      let result;
+      try {
+        result = await httpClient.post(url, {agent, json: zcap});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      should.not.exist(result);
+      err.data.type.should.equal('ValidationError');
+      err.data.message.should.equal(
+        'A validation error occured in the \'Delegated ZCAP\' validator.');
+    });
+    it('revokes a zcap', async () => {
+      const config = await helpers.createExchangerConfig({capabilityAgent});
+
+      const capabilityAgent2 = await CapabilityAgent.fromSecret(
+        {secret: 's2', handle: 'h2'});
+
+      const zcap = await helpers.delegate({
+        controller: capabilityAgent2.id,
+        invocationTarget: config.id,
+        delegator: capabilityAgent
+      });
+
+      // zcap should work to get config
+      const zcapClient = helpers.createZcapClient(
+        {capabilityAgent: capabilityAgent2});
+      const {data} = await zcapClient.read({capability: zcap});
+      data.should.have.keys([
+        'controller', 'id', 'sequence', 'meterId'
+      ]);
+      data.id.should.equal(config.id);
+
+      // revoke zcap
+      await helpers.revokeDelegatedCapability({
+        serviceObjectId: config.id,
+        capabilityToRevoke: zcap,
+        invocationSigner: capabilityAgent.getSigner()
+      });
+
+      // now getting config should fail
+      let err;
+      try {
+        await zcapClient.read({capability: zcap});
+      } catch(e) {
+        err = e;
+      }
+      should.exist(err);
+      err.data.type.should.equal('NotAllowedError');
+    });
+  }); // end revocations
+});

--- a/test/mocha/backwards-compatibility/20-vcapi.js
+++ b/test/mocha/backwards-compatibility/20-vcapi.js
@@ -1,0 +1,688 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {agent} from '@bedrock/https-agent';
+import {httpClient} from '@digitalbazaar/http-client';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+const {
+  credentialTemplate, credentialRequestTemplate,
+  genericCredentialRequestTemplate, genericCredentialTemplate,
+  prcCredentialTemplate
+} = mockData;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API delivery', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: credentialTemplate
+    }];
+    const exchangerConfig = await helpers.createExchangerConfig(
+      {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+
+    const chapiRequest = {
+      VerifiablePresentation: {
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // post empty body and get VP w/VCs in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    const response = await httpClient.post(url, {agent, json: {}});
+    const {verifiablePresentation: vp} = response.data;
+    // ensure credential subject ID matches static DID
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+  });
+
+  it('should fail when reusing a completed exchange', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+
+    // exchange state should be pending
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('pending');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+
+    // exchange state should be pending using oauth2 access
+    {
+      let err;
+      try {
+        const exchangerId = exchangeId.slice(
+          0, exchangeId.lastIndexOf('/exchanges/'));
+        const accessToken = await helpers.getOAuth2AccessToken(
+          {configId: exchangerId, action: 'read', target: '/'});
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, accessToken});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('pending');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+
+    const chapiRequest = {
+      VerifiablePresentation: {
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // post empty body and get VP w/VCs in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    const response = await httpClient.post(url, {agent, json: {}});
+    const {verifiablePresentation: vp} = response.data;
+    // ensure credential subject ID matches static DID
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+
+    // now try to reuse the exchange
+    let err;
+    try {
+      await httpClient.post(url, {agent, json: {}});
+    } catch(error) {
+      err = error;
+    }
+    should.exist(err);
+    should.equal(err?.data?.name, 'DuplicateError');
+
+    // exchange state should be complete
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+
+    // getting exchange state w/o auth should fail
+    // FIXME: make this its own test
+    {
+      let err;
+      try {
+        await httpClient.get(exchangeId, {agent});
+      } catch(error) {
+        err = error;
+      }
+      should.exist(err);
+      should.exist(err.data?.name);
+      err.data.name.should.equal('NotAllowedError');
+    }
+  });
+});
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API delivery using credential request template', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: credentialRequestTemplate
+    }];
+    const exchangerConfig = await helpers.createExchangerConfig(
+      {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+
+    const chapiRequest = {
+      VerifiablePresentation: {
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // post empty body and get VP w/VCs in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    const response = await httpClient.post(url, {agent, json: {}});
+    const {verifiablePresentation: vp} = response.data;
+    // ensure credential subject ID matches static DID
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID is NOT present
+    should.not.exist(vc.id);
+  });
+});
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API delivery using prc template', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: prcCredentialTemplate
+    }];
+    const exchangerConfig = await helpers.createExchangerConfig(
+      {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.prcCredentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+    const chapiRequest = {
+      VerifiablePresentation: {
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // post empty body and get VP w/VCs in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    let response;
+    let err;
+    try {
+      response = await httpClient.post(url, {agent, json: {}});
+    } catch(e) {
+      err = e;
+    }
+    should.exist(response);
+    should.not.exist(err);
+    const {verifiablePresentation: vp} = response.data;
+    // ensure credential subject ID matches static DID
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal('did:example:b34ca6cd37bbf23');
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+  });
+});
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API delivery using generic credential request ' +
+  'template', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: genericCredentialRequestTemplate
+    }];
+    const exchangerConfig = await helpers.createExchangerConfig(
+      {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap,
+      variables: {
+        credentialId,
+        credentialRequest: `{
+          'options': {
+            'credentialId': $credentialId
+          },
+          'credential': {
+            '@context': [
+              'https://www.w3.org/2018/credentials/v1',
+              'https://www.w3.org/2018/credentials/examples/v1'
+            ],
+            'type': [
+              'VerifiableCredential',
+              'UniversityDegreeCredential'
+            ],
+            'issuanceDate': $issuanceDate,
+            'credentialSubject': {
+              'id': 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+              'degree': {
+                'type': 'BachelorDegree',
+                'name': 'Bachelor of Science and Arts'
+              }
+            }
+          }
+        }`
+      }
+    });
+    const chapiRequest = {
+      VerifiablePresentation: {
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // post empty body and get VP w/VCs in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    let response;
+    let err;
+    try {
+      response = await httpClient.post(url, {agent, json: {}});
+    } catch(e) {
+      err = e;
+    }
+    should.exist(response);
+    should.not.exist(err);
+    const {verifiablePresentation: vp} = response.data;
+    // ensure credential subject ID matches static DID
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID is NOT present
+    should.not.exist(vc.id);
+  });
+});
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API delivery using generic template', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: genericCredentialTemplate
+    }];
+    const exchangerConfig = await helpers.createExchangerConfig(
+      {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap,
+      variables: {
+        credentialId,
+        vc: `{
+          '@context': [
+            'https://www.w3.org/2018/credentials/v1',
+            'https://www.w3.org/2018/credentials/examples/v1'
+          ],
+          'id': $credentialId,
+          'type': [
+            'VerifiableCredential',
+            'UniversityDegreeCredential'
+          ],
+          'issuanceDate': $issuanceDate,
+          'credentialSubject': {
+            'id': 'did:example:ebfeb1f712ebc6f1c276e12ec21',
+            'degree': {
+              'type': 'BachelorDegree',
+              'name': 'Bachelor of Science and Arts'
+            }
+          }
+        }`
+      }
+    });
+    const chapiRequest = {
+      VerifiablePresentation: {
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // post empty body and get VP w/VCs in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    let response;
+    let err;
+    try {
+      response = await httpClient.post(url, {agent, json: {}});
+    } catch(e) {
+      err = e;
+    }
+    should.exist(response);
+    should.not.exist(err);
+    const {verifiablePresentation: vp} = response.data;
+    // ensure credential subject ID matches static DID
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+  });
+});

--- a/test/mocha/backwards-compatibility/21-vcapi-did-authn.js
+++ b/test/mocha/backwards-compatibility/21-vcapi-did-authn.js
@@ -1,0 +1,638 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {agent} from '@bedrock/https-agent';
+import {httpClient} from '@digitalbazaar/http-client';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+const {
+  baseUrl, didAuthnCredentialTemplate, genericCredentialTemplate
+} = mockData;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API delivery + DID authn', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: didAuthnCredentialTemplate
+    }];
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        createChallenge: true,
+        verifiablePresentationRequest: {
+          query: {
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}]
+          },
+          domain: baseUrl
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
+      oauth2: true
+    });
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass when sending VP in single call', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+      // FIXME: add test with a `requiredDid` -- any presented VPs must include
+      // DID Authn with a DID that matches the `requiredDid` value -- however,
+      // this might be generalized into some other kind of VPR satisfaction
+      // mechanism
+    });
+
+    const chapiRequest = {
+      VerifiablePresentation: {
+        query: {
+          type: 'DIDAuthentication'
+        },
+        challenge: exchangeId.slice(exchangeId.lastIndexOf('/') + 1),
+        domain: baseUrl,
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // generate VP
+    const {domain, challenge} = parsedChapiRequest.VerifiablePresentation;
+    const {verifiablePresentation, did} = await helpers.createDidAuthnVP(
+      {domain, challenge});
+
+    // post VP to get VP in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    const response = await httpClient.post(
+      url, {agent, json: {verifiablePresentation}});
+    should.exist(response?.data?.verifiablePresentation);
+    // ensure DID in VC matches `did`
+    const {verifiablePresentation: vp} = response.data;
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(did);
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+  });
+
+  it('should pass when sending VP in second call', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+
+    // exchange state should be pending
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('pending');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+
+    const chapiRequest = {
+      VerifiablePresentation: {
+        query: {
+          type: 'DIDAuthentication'
+        },
+        challenge: '3182bdea-63d9-11ea-b6de-3b7c1404d57f',
+        domain: baseUrl,
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // post empty body to get VPR in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    const vprResponse = await httpClient.post(url, {agent, json: {}});
+    should.exist(vprResponse?.data?.verifiablePresentationRequest);
+
+    // exchange state should be active
+    {
+      // give exchange time to update as it can be an asynchronous state change
+      await new Promise(r => setTimeout(r, 500));
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('active');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+
+    // generate VP
+    const {domain, challenge} = vprResponse.data.verifiablePresentationRequest;
+    const {verifiablePresentation, did} = await helpers.createDidAuthnVP(
+      {domain, challenge});
+
+    // post VP to get VP w/VCs in response
+    const vpResponse = await httpClient.post(
+      url, {agent, json: {verifiablePresentation}});
+    should.exist(vpResponse?.data?.verifiablePresentation);
+    const {verifiablePresentation: vp} = vpResponse.data;
+    // ensure DID in VC matches `did`
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(did);
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+
+    // exchange state should be complete
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+});
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API delivery + DID authn + generic template', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: genericCredentialTemplate
+    }];
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        createChallenge: true,
+        verifiablePresentationRequest: {
+          query: {
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}]
+          },
+          domain: baseUrl
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
+      oauth2: true
+    });
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing a DID Authn request and interact VC-API
+    exchange URL through CHAPI. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap,
+      variables: {
+        credentialId,
+        vc: `{
+            '@context': [
+              'https://www.w3.org/2018/credentials/v1',
+              'https://www.w3.org/2018/credentials/examples/v1'
+            ],
+            'id': $credentialId,
+            'issuanceDate': $issuanceDate,
+            'type': [
+              'VerifiableCredential',
+              'UniversityDegreeCredential'
+            ],
+            'credentialSubject': {
+              'id': $results.didAuthn.did,
+              'degree': {
+                'type': 'BachelorDegree',
+                'name': 'Bachelor of Science and Arts'
+              }
+            }
+          }`
+      }
+      // FIXME: add test with a `requiredDid` -- any presented VPs must include
+      // DID Authn with a DID that matches the `requiredDid` value -- however,
+      // this might be generalized into some other kind of VPR satisfaction
+      // mechanism
+    });
+
+    const chapiRequest = {
+      VerifiablePresentation: {
+        query: {
+          type: 'DIDAuthentication'
+        },
+        challenge: exchangeId.slice(exchangeId.lastIndexOf('/') + 1),
+        domain: baseUrl,
+        interact: {
+          service: [{
+            type: 'VerifiableCredentialApiExchangeService',
+            serviceEndpoint: exchangeId
+          }]
+        }
+      }
+    };
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+
+    // generate VP
+    const {domain, challenge} = parsedChapiRequest.VerifiablePresentation;
+    const {verifiablePresentation, did} = await helpers.createDidAuthnVP(
+      {domain, challenge});
+
+    // post VP to get VP in response
+    const {
+      VerifiablePresentation: {
+        interact: {
+          service: [{serviceEndpoint: url}]
+        }
+      }
+    } = parsedChapiRequest;
+    const response = await httpClient.post(
+      url, {agent, json: {verifiablePresentation}});
+    should.exist(response?.data?.verifiablePresentation);
+    // ensure DID in VC matches `did`
+    const {verifiablePresentation: vp} = response.data;
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(did);
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+  });
+});
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API presentation + templated DID authn', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        stepTemplate: {
+          type: 'jsonata',
+          template: `
+          {
+            "createChallenge": true,
+            "verifiablePresentationRequest": {
+              "query": query,
+              "domain": domain
+            }
+          }`
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, steps, initialStep
+    });
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // create an exchange with appropriate variables for the step template
+    const exchange = {
+      // 15 minute expiry in seconds
+      ttl: 60 * 15,
+      // template variables
+      variables: {
+        query: {
+          type: 'DIDAuthentication',
+          acceptedMethods: [{method: 'key'}]
+        },
+        domain: 'some-random-string-that-should-work'
+      }
+    };
+    const {id: exchangeId} = await helpers.createExchange({
+      url: `${exchangerId}/exchanges`,
+      capabilityAgent, capability: exchangerRootZcap, exchange
+    });
+
+    // post to exchange URL to get expected VPR
+    let response = await httpClient.post(
+      exchangeId, {agent, json: {}});
+    should.exist(response?.data?.verifiablePresentationRequest);
+    const {data: {verifiablePresentationRequest: vpr}} = response;
+    const expectedVpr = {
+      query: {
+        type: 'DIDAuthentication',
+        acceptedMethods: [{method: 'key'}]
+      },
+      domain: exchange.variables.domain
+    };
+    expectedVpr.query.should.deep.equal(vpr.query);
+    expectedVpr.domain.should.deep.equal(vpr.domain);
+    should.exist(vpr.challenge);
+
+    // generate VP
+    const {domain, challenge} = vpr;
+    const {verifiablePresentation, did} = await helpers.createDidAuthnVP(
+      {domain, challenge});
+
+    response = await httpClient.post(
+      exchangeId, {agent, json: {verifiablePresentation}});
+    // should be no VP nor VPR in the response, indicating the end of the
+    // exchange (and nothing was issued, just presented)
+    should.not.exist(response?.data?.verifiablePresentation);
+    should.not.exist(response?.data?.verifiablePresentationRequest);
+
+    // exchange should be complete and contain the submitted VPR
+    // exchange state should be complete
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+        should.exist(exchange?.variables?.results?.didAuthn);
+        should.exist(
+          exchange?.variables?.results?.didAuthn?.verifiablePresentation);
+        exchange?.variables?.results?.didAuthn.did.should.equal(did);
+        exchange.variables.results.didAuthn.verifiablePresentation
+          .should.deep.equal(verifiablePresentation);
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+});
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API presentation + templated VPR', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        stepTemplate: {
+          type: 'jsonata',
+          template: `
+          {
+            "createChallenge": true,
+            "verifiablePresentationRequest": verifiablePresentationRequest
+          }`
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, steps, initialStep
+    });
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // create an exchange with appropriate variables for the step template
+    const exchange = {
+      // 15 minute expiry in seconds
+      ttl: 60 * 15,
+      // template variables
+      variables: {
+        verifiablePresentationRequest: {
+          query: {
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}]
+          },
+          domain: baseUrl
+        }
+      }
+    };
+    const {id: exchangeId} = await helpers.createExchange({
+      url: `${exchangerId}/exchanges`,
+      capabilityAgent, capability: exchangerRootZcap, exchange
+    });
+
+    // post to exchange URL to get expected VPR
+    let response = await httpClient.post(
+      exchangeId, {agent, json: {}});
+    should.exist(response?.data?.verifiablePresentationRequest);
+    const {data: {verifiablePresentationRequest: vpr}} = response;
+    const expectedVpr = {
+      query: {
+        type: 'DIDAuthentication',
+        acceptedMethods: [{method: 'key'}]
+      },
+      domain: baseUrl
+    };
+    expectedVpr.query.should.deep.equal(vpr.query);
+    expectedVpr.domain.should.deep.equal(vpr.domain);
+    should.exist(vpr.challenge);
+
+    // generate VP
+    const {domain, challenge} = vpr;
+    const {verifiablePresentation, did} = await helpers.createDidAuthnVP(
+      {domain, challenge});
+
+    response = await httpClient.post(
+      exchangeId, {agent, json: {verifiablePresentation}});
+    // should be no VP nor VPR in the response, indicating the end of the
+    // exchange (and nothing was issued, just presented)
+    should.not.exist(response?.data?.verifiablePresentation);
+    should.not.exist(response?.data?.verifiablePresentationRequest);
+
+    // exchange should be complete and contain the submitted VPR
+    // exchange state should be complete
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+        should.exist(exchange?.variables?.results?.didAuthn);
+        should.exist(
+          exchange?.variables?.results?.didAuthn?.verifiablePresentation);
+        exchange?.variables?.results?.didAuthn.did.should.equal(did);
+        exchange.variables.results.didAuthn.verifiablePresentation
+          .should.deep.equal(verifiablePresentation);
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+});

--- a/test/mocha/backwards-compatibility/22-vcapi-verify-vc-issue-vc.js
+++ b/test/mocha/backwards-compatibility/22-vcapi-verify-vc-issue-vc.js
@@ -1,0 +1,269 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {agent} from '@bedrock/https-agent';
+import {httpClient} from '@digitalbazaar/http-client';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+const {
+  baseUrl, didAuthnCredentialTemplate
+} = mockData;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ VC-API delivery + DID authn + VC request', () => {
+  let capabilityAgent;
+
+  // provision a VC to use in the workflow below
+  let verifiableCredential;
+  let did;
+  let signer;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: didAuthnCredentialTemplate
+    }];
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        createChallenge: true,
+        verifiablePresentationRequest: {
+          query: {
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}]
+          },
+          domain: baseUrl
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
+      oauth2: true
+    });
+    const workflowId = exchangerConfig.id;
+    const workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
+
+    // use workflow to provision verifiable credential
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId: workflowId,
+      exchangerRootZcap: workflowRootZcap
+    });
+
+    // generate VP
+    ({did, signer} = await helpers.createDidProofSigner());
+    const {verifiablePresentation} = await helpers.createDidAuthnVP({
+      domain: baseUrl,
+      challenge: exchangeId.slice(exchangeId.lastIndexOf('/') + 1),
+      did, signer
+    });
+
+    // post VP to get VP w/VC in response
+    const response = await httpClient.post(
+      exchangeId, {agent, json: {verifiablePresentation}});
+    const {verifiablePresentation: vp} = response.data;
+    verifiableCredential = vp.verifiableCredential[0];
+  });
+
+  // provision workflow that will require the provisioned VC above
+  let workflowId;
+  let workflowRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: didAuthnCredentialTemplate
+    }];
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step, additionally require VC that was issued from
+      // workflow 1
+      didAuthn: {
+        createChallenge: true,
+        verifiablePresentationRequest: {
+          query: [{
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}]
+          }, {
+            type: 'QueryByExample',
+            credentialQuery: [{
+              reason: 'We require a verifiable credential to pass this test',
+              example: {
+                '@context': [
+                  'https://www.w3.org/2018/credentials/v1',
+                  'https://www.w3.org/2018/credentials/examples/v1'
+                ],
+                type: 'UniversityDegreeCredential'
+              }
+            }]
+          }],
+          domain: baseUrl
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
+      oauth2: true
+    });
+    workflowId = exchangerConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
+  });
+
+  it('should pass when sending VP in single call', async () => {
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId: workflowId,
+      exchangerRootZcap: workflowRootZcap
+    });
+
+    // generate VP
+    const {verifiablePresentation} = await helpers.createDidAuthnVP({
+      domain: baseUrl,
+      challenge: exchangeId.slice(exchangeId.lastIndexOf('/') + 1),
+      did, signer, verifiableCredential
+    });
+
+    // post VP to get VP in response
+    const response = await httpClient.post(
+      exchangeId, {agent, json: {verifiablePresentation}});
+    should.exist(response?.data?.verifiablePresentation);
+    // ensure DID in VC matches `did`
+    const {verifiablePresentation: vp} = response.data;
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(did);
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+
+    // exchange should be complete and contain the VP and original VC
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+        should.exist(exchange?.variables?.results?.didAuthn);
+        should.exist(
+          exchange?.variables?.results?.didAuthn?.verifiablePresentation);
+        exchange?.variables?.results?.didAuthn.did.should.equal(did);
+        exchange.variables.results.didAuthn.verifiablePresentation
+          .should.deep.equal(verifiablePresentation);
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+
+  it('should pass when sending VP in second call', async () => {
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId: workflowId,
+      exchangerRootZcap: workflowRootZcap
+    });
+
+    // post empty body to get VPR in response
+    const vprResponse = await httpClient.post(exchangeId, {agent, json: {}});
+    should.exist(vprResponse?.data?.verifiablePresentationRequest);
+
+    // generate VP
+    const {domain, challenge} = vprResponse.data.verifiablePresentationRequest;
+    const {verifiablePresentation} = await helpers.createDidAuthnVP({
+      domain, challenge,
+      did, signer, verifiableCredential
+    });
+
+    // post VP to get VP w/VCs in response
+    const vpResponse = await httpClient.post(
+      exchangeId, {agent, json: {verifiablePresentation}});
+    should.exist(vpResponse?.data?.verifiablePresentation);
+    const {verifiablePresentation: vp} = vpResponse.data;
+    // ensure DID in VC matches `did`
+    should.exist(vp?.verifiableCredential?.[0]?.credentialSubject?.id);
+    const {verifiableCredential: [vc]} = vp;
+    vc.credentialSubject.id.should.equal(did);
+    // ensure VC ID matches
+    should.exist(vc.id);
+    vc.id.should.equal(credentialId);
+
+    // exchange should be complete and contain the VP and original VC
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+        should.exist(exchange?.variables?.results?.didAuthn);
+        should.exist(
+          exchange?.variables?.results?.didAuthn?.verifiablePresentation);
+        exchange?.variables?.results?.didAuthn.did.should.equal(did);
+        exchange.variables.results.didAuthn.verifiablePresentation
+          .should.deep.equal(verifiablePresentation);
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+});

--- a/test/mocha/backwards-compatibility/30-oid4vci.js
+++ b/test/mocha/backwards-compatibility/30-oid4vci.js
@@ -1,0 +1,301 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {OID4Client, parseCredentialOfferUrl} from '@digitalbazaar/oid4-client';
+import {agent} from '@bedrock/https-agent';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+const {credentialTemplate} = mockData;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/OID4VCI delivery', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: credentialTemplate
+    }];
+    const exchangerConfig = await helpers.createExchangerConfig(
+      {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass w/ pre-authorized code flow', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing an OID4VCI issuance initiation URL
+    through a CHAPI OID4VCI request. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    // pre-authorized flow, issuer-initiated
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {openIdUrl: offerUrl} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+    const chapiRequest = {OID4VC: offerUrl};
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+    const offer = parseCredentialOfferUrl({url: parsedChapiRequest.OID4VC});
+
+    // wallet / client gets access token
+    const client = await OID4Client.fromCredentialOffer({offer, agent});
+
+    // wallet / client receives credential
+    const result = await client.requestCredential({
+      credentialDefinition: mockData.credentialDefinition,
+      agent
+    });
+    should.exist(result);
+    result.should.include.keys(['format', 'credential']);
+    result.format.should.equal('ldp_vc');
+    // ensure credential subject ID matches static DID
+    should.exist(result.credential?.credentialSubject?.id);
+    result.credential.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID matches
+    should.exist(result.credential.id);
+    result.credential.id.should.equal(credentialId);
+
+    // exchange state should be complete
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: offer.credential_issuer, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+
+  it('should pass w/ pre-authorized code flow w/ AS key pair', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing an OID4VCI issuance initiation URL
+    through a CHAPI OID4VCI request. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    // pre-authorized flow, issuer-initiated
+    const credentialId = `urn:uuid:${uuid()}`;
+    // generate authorization server key pair
+    const openIdKeyPair = await helpers.generateKeyPair();
+    const {openIdUrl: issuanceUrl} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap,
+      openIdKeyPair
+    });
+
+    const chapiRequest = {OID4VC: issuanceUrl};
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+    const offer = parseCredentialOfferUrl({url: parsedChapiRequest.OID4VC});
+
+    // wallet / client gets access token
+    const client = await OID4Client.fromCredentialOffer({offer, agent});
+
+    // wallet / client receives credential
+    const result = await client.requestCredential({
+      credentialDefinition: mockData.credentialDefinition,
+      agent
+    });
+    should.exist(result);
+    result.should.include.keys(['format', 'credential']);
+    result.format.should.equal('ldp_vc');
+    // ensure credential subject ID matches static DID
+    should.exist(result.credential?.credentialSubject?.id);
+    result.credential.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID matches
+    should.exist(result.credential.id);
+    result.credential.id.should.equal(credentialId);
+  });
+
+  it('should pass w/ "types" in credential definition', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing an OID4VCI issuance initiation URL
+    through a CHAPI OID4VCI request. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    // pre-authorized flow, issuer-initiated
+    const credentialId = `urn:uuid:${uuid()}`;
+    // generate authorization server key pair
+    const openIdKeyPair = await helpers.generateKeyPair();
+    const {openIdUrl: issuanceUrl} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap,
+      openIdKeyPair
+    });
+
+    const chapiRequest = {OID4VC: issuanceUrl};
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+    const offer = parseCredentialOfferUrl({url: parsedChapiRequest.OID4VC});
+
+    // wallet / client gets access token
+    const client = await OID4Client.fromCredentialOffer({offer, agent});
+
+    // send OID4VCI draft 20 credential definition w/"types" which should
+    // work with backwards compatibility support
+    const credentialDefinition = {
+      ...mockData.credentialDefinition,
+      types: mockData.credentialDefinition.type
+    };
+
+    // wallet / client receives credential
+    const result = await client.requestCredential({
+      credentialDefinition,
+      agent
+    });
+    should.exist(result);
+    result.should.include.keys(['format', 'credential']);
+    result.format.should.equal('ldp_vc');
+    // ensure credential subject ID matches static DID
+    should.exist(result.credential?.credentialSubject?.id);
+    result.credential.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID matches
+    should.exist(result.credential.id);
+    result.credential.id.should.equal(credentialId);
+  });
+
+  it('should fail when reusing a completed exchange', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing an OID4VCI issuance initiation URL
+    through a CHAPI OID4VCI request. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    // pre-authorized flow, issuer-initiated
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {openIdUrl: issuanceUrl} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+    const chapiRequest = {OID4VC: issuanceUrl};
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+    const offer = parseCredentialOfferUrl({url: parsedChapiRequest.OID4VC});
+
+    // wallet / client gets access token
+    const client = await OID4Client.fromCredentialOffer({offer, agent});
+
+    // wallet / client receives credential
+    const result = await client.requestCredential({
+      credentialDefinition: mockData.credentialDefinition,
+      agent
+    });
+    should.exist(result);
+    result.should.include.keys(['format', 'credential']);
+    result.format.should.equal('ldp_vc');
+    // ensure credential subject ID matches static DID
+    should.exist(result.credential?.credentialSubject?.id);
+    result.credential.credentialSubject.id.should.equal(
+      'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    // ensure VC ID matches
+    should.exist(result.credential.id);
+    result.credential.id.should.equal(credentialId);
+
+    // now try to reuse the exchange
+    let err;
+    try {
+      await client.requestCredential({
+        credentialDefinition: mockData.credentialDefinition,
+        agent
+      });
+    } catch(error) {
+      err = error;
+    }
+    should.exist(err);
+    should.equal(err?.cause?.data?.name, 'DuplicateError');
+  });
+});

--- a/test/mocha/backwards-compatibility/31-oid4vci-did-authn.js
+++ b/test/mocha/backwards-compatibility/31-oid4vci-did-authn.js
@@ -1,0 +1,127 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {OID4Client, parseCredentialOfferUrl} from '@digitalbazaar/oid4-client';
+import {agent} from '@bedrock/https-agent';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+const {baseUrl, didAuthnCredentialTemplate} = mockData;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/OID4VCI delivery + DID authn', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: didAuthnCredentialTemplate
+    }];
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        createChallenge: true,
+        // will be used by VC-API
+        verifiablePresentationRequest: {
+          query: {
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}]
+          },
+          domain: baseUrl
+        },
+        // will be used by OID4VCI
+        jwtDidProofRequest: {
+          acceptedMethods: [{method: 'key'}]
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
+      oauth2: true
+    });
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass w/ pre-authorized code flow', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing an OID4VCI issuance initiation URL
+    through a CHAPI OID4VCI request. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    // pre-authorized flow, issuer-initiated
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {openIdUrl: issuanceUrl} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+      // FIXME: add test with a `requiredDid` -- any presented VPs must include
+      // DID Authn with a DID that matches the `requiredDid` value -- however,
+      // this might be generalized into some other kind of VPR satisfaction
+      // mechanism
+    });
+    const chapiRequest = {OID4VC: issuanceUrl};
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+    const offer = parseCredentialOfferUrl({url: parsedChapiRequest.OID4VC});
+
+    // wallet / client gets access token
+    const client = await OID4Client.fromCredentialOffer({offer, agent});
+
+    const {did, signer: didProofSigner} = await helpers.createDidProofSigner();
+
+    // wallet / client receives credential
+    const result = await client.requestCredential({
+      credentialDefinition: mockData.credentialDefinition,
+      did,
+      didProofSigner,
+      agent
+    });
+    should.exist(result);
+    result.should.include.keys(['format', 'credential']);
+    result.format.should.equal('ldp_vc');
+    // ensure credential subject ID matches generated DID
+    should.exist(result.credential?.credentialSubject?.id);
+    result.credential.credentialSubject.id.should.equal(did);
+    // ensure VC ID matches
+    should.exist(result.credential.id);
+    result.credential.id.should.equal(credentialId);
+  });
+});

--- a/test/mocha/backwards-compatibility/32-batch-oid4vci.js
+++ b/test/mocha/backwards-compatibility/32-batch-oid4vci.js
@@ -1,0 +1,117 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {OID4Client, parseCredentialOfferUrl} from '@digitalbazaar/oid4-client';
+import {agent} from '@bedrock/https-agent';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+const {credentialTemplate} = mockData;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/batch OID4VCI delivery', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: credentialTemplate.replace(
+        'credentialId', 'credentialId1')
+    }, {
+      type: 'jsonata',
+      template: credentialTemplate.replace(
+        'credentialId', 'credentialId2')
+    }];
+    const exchangerConfig = await helpers.createExchangerConfig(
+      {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass w/ pre-authorized code flow', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing an OID4VCI issuance initiation URL
+    through a CHAPI OID4VCI request. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    // pre-authorized flow, issuer-initiated
+    const credentialId1 = `urn:uuid:${uuid()}`;
+    const credentialId2 = `urn:uuid:${uuid()}`;
+    const {openIdUrl: issuanceUrl} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: [
+        mockData.credentialDefinition,
+        mockData.credentialDefinition
+      ],
+      variables: {
+        credentialId1,
+        credentialId2
+      },
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+    const chapiRequest = {OID4VC: issuanceUrl};
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+    const offer = parseCredentialOfferUrl({url: parsedChapiRequest.OID4VC});
+
+    // wallet / client gets access token
+    const client = await OID4Client.fromCredentialOffer({offer, agent});
+
+    // wallet / client requests credentials
+    const result = await client.requestCredentials({
+      requests: [{
+        credential_definition: mockData.credentialDefinition
+      }, {
+        credential_definition: mockData.credentialDefinition
+      }],
+      agent
+    });
+    should.exist(result);
+    result.should.have.keys(['credential_responses']);
+    result.credential_responses.should.be.an('array');
+    result.credential_responses.length.should.equal(2);
+    result.credential_responses.forEach(cr => {
+      cr.should.include.keys(['format', 'credential']);
+      cr.format.should.equal('ldp_vc');
+      // ensure credential subject ID matches static DID
+      should.exist(cr.credential?.credentialSubject?.id);
+      cr.credential.credentialSubject.id.should.equal(
+        'did:example:ebfeb1f712ebc6f1c276e12ec21');
+    });
+    result.credential_responses[0].credential.id.should.equal(credentialId1);
+    result.credential_responses[1].credential.id.should.equal(credentialId2);
+  });
+});

--- a/test/mocha/backwards-compatibility/33-batch-oid4vci-did-authn.js
+++ b/test/mocha/backwards-compatibility/33-batch-oid4vci-did-authn.js
@@ -1,0 +1,147 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {OID4Client, parseCredentialOfferUrl} from '@digitalbazaar/oid4-client';
+import {agent} from '@bedrock/https-agent';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+const {baseUrl, didAuthnCredentialTemplate} = mockData;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/batch OID4VCI delivery + DID authn', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: didAuthnCredentialTemplate.replace(
+        'credentialId', 'credentialId1')
+    }, {
+      type: 'jsonata',
+      template: didAuthnCredentialTemplate.replace(
+        'credentialId', 'credentialId2')
+    }];
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        createChallenge: true,
+        // will be used by VC-API
+        verifiablePresentationRequest: {
+          query: {
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}]
+          },
+          domain: baseUrl
+        },
+        // will be used by OID4VCI
+        jwtDidProofRequest: {
+          acceptedMethods: [{method: 'key'}]
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
+      oauth2: true
+    });
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass w/ pre-authorized code flow', async () => {
+    // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+
+    /* This flow demonstrates passing an OID4VCI issuance initiation URL
+    through a CHAPI OID4VCI request. The request is passed to a "Claimed URL"
+    which was registered on a user's device by a native app. The native app's
+    domain also published a "manifest.json" file that expressed the same
+    "Claimed URL" via `credential_handler.url='https://myapp.example/ch'` and
+    `credential_handler.launchType='redirect'` (TBD). */
+
+    // pre-authorized flow, issuer-initiated
+    const credentialId1 = `urn:uuid:${uuid()}`;
+    const credentialId2 = `urn:uuid:${uuid()}`;
+    const {openIdUrl: issuanceUrl} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: [
+        mockData.credentialDefinition,
+        mockData.credentialDefinition
+      ],
+      variables: {
+        credentialId1,
+        credentialId2
+      },
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+      // FIXME: add test with a `requiredDid` -- any presented VPs must include
+      // DID Authn with a DID that matches the `requiredDid` value -- however,
+      // this might be generalized into some other kind of VPR satisfaction
+      // mechanism
+    });
+    const chapiRequest = {OID4VC: issuanceUrl};
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+    const offer = parseCredentialOfferUrl({url: parsedChapiRequest.OID4VC});
+
+    // wallet / client gets access token
+    const client = await OID4Client.fromCredentialOffer({offer, agent});
+
+    const {did, signer: didProofSigner} = await helpers.createDidProofSigner();
+
+    // wallet / client requests credentials
+    const result = await client.requestCredentials({
+      requests: [{
+        credential_definition: mockData.credentialDefinition
+      }, {
+        credential_definition: mockData.credentialDefinition
+      }],
+      did,
+      didProofSigner,
+      agent
+    });
+    should.exist(result);
+    result.should.have.keys(['credential_responses']);
+    result.credential_responses.should.be.an('array');
+    result.credential_responses.length.should.equal(2);
+    result.credential_responses.forEach(cr => {
+      cr.should.include.keys(['format', 'credential']);
+      cr.format.should.equal('ldp_vc');
+      // ensure credential subject ID matches static DID
+      should.exist(cr.credential?.credentialSubject?.id);
+      cr.credential.credentialSubject.id.should.equal(did);
+    });
+    result.credential_responses[0].credential.id.should.equal(credentialId1);
+    result.credential_responses[1].credential.id.should.equal(credentialId2);
+  });
+});

--- a/test/mocha/backwards-compatibility/34-oid4vp.js
+++ b/test/mocha/backwards-compatibility/34-oid4vp.js
@@ -1,0 +1,404 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {agent} from '@bedrock/https-agent';
+import {httpClient} from '@digitalbazaar/http-client';
+import {mockData} from './mock.data.js';
+import {oid4vp} from '@digitalbazaar/oid4-client';
+import {v4 as uuid} from 'uuid';
+
+const {baseUrl, alumniCredentialTemplate} = mockData;
+const {getAuthorizationRequest} = oid4vp;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ OID4VP presentation w/DID Authn only', () => {
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        stepTemplate: {
+          type: 'jsonata',
+          template: `
+          {
+            "createChallenge": true,
+            "verifiablePresentationRequest": verifiablePresentationRequest,
+            "openId": {
+              "createAuthorizationRequest": "authorizationRequest",
+              "client_id_scheme": "redirect_uri",
+              "client_id": globals.exchanger.id &
+                "/exchanges/" &
+                globals.exchange.id &
+                "/openid/client/authorization/response"
+            }
+          }`
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, steps, initialStep, oauth2: true
+    });
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // create an exchange with appropriate variables for the step template
+    const exchange = {
+      // 15 minute expiry in seconds
+      ttl: 60 * 15,
+      // template variables
+      variables: {
+        verifiablePresentationRequest: {
+          query: {
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}],
+            acceptedCryptosuites: [{cryptosuite: 'Ed25519Signature2020'}]
+          },
+          domain: baseUrl
+        }
+      }
+    };
+    const {id: exchangeId} = await helpers.createExchange({
+      url: `${exchangerId}/exchanges`,
+      capabilityAgent, capability: exchangerRootZcap, exchange
+    });
+
+    // request URI
+    const authzReqUrl = `${exchangeId}/openid/client/authorization/request`;
+
+    // `openid4vp` URL would be:
+    /*
+    const searchParams = new URLSearchParams({
+      client_id: `${exchangeId}/openid/client/authorization/response`,
+      request_uri: authzReqUrl
+    });
+    const openid4vpUrl = 'openid4vp://authorize?' + searchParams.toString();*/
+
+    // exchange state should be pending
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('pending');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+
+    // get authorization request
+    const {authorizationRequest} = await getAuthorizationRequest(
+      {url: authzReqUrl, agent});
+
+    // exchange state should be active
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('active');
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+
+    should.exist(authorizationRequest);
+    should.exist(authorizationRequest.presentation_definition);
+    authorizationRequest.presentation_definition.id.should.be.a('string');
+    authorizationRequest.presentation_definition.input_descriptors.should.be
+      .an('array');
+    authorizationRequest.response_mode.should.equal('direct_post');
+    authorizationRequest.nonce.should.be.a('string');
+
+    // generate VPR from authorization request
+    const {verifiablePresentationRequest} = await oid4vp.toVpr(
+      {authorizationRequest});
+
+    // generate VP
+    const {domain, challenge} = verifiablePresentationRequest;
+    const {verifiablePresentation, did} = await helpers.createDidAuthnVP(
+      {domain, challenge});
+
+    // send authorization response
+    const {
+      result, presentationSubmission
+    } = await oid4vp.sendAuthorizationResponse({
+      verifiablePresentation, authorizationRequest, agent
+    });
+    // should be only an optional `redirect_uri` in the response
+    should.exist(result);
+    //should.exist(result.redirect_uri);
+
+    // exchange should be complete and contain the VP and open ID results
+    // exchange state should be complete
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+        should.exist(exchange?.variables?.results?.didAuthn);
+        should.exist(
+          exchange?.variables?.results?.didAuthn?.verifiablePresentation);
+        exchange?.variables?.results?.didAuthn.did.should.equal(did);
+        exchange.variables.results.didAuthn.verifiablePresentation
+          .should.deep.equal(verifiablePresentation);
+        should.exist(exchange.variables.results.didAuthn.openId);
+        exchange.variables.results.didAuthn.openId.authorizationRequest
+          .should.deep.equal(authorizationRequest);
+        exchange.variables.results.didAuthn.openId.presentationSubmission
+          .should.deep.equal(presentationSubmission);
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+});
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/ OID4VP presentation w/VC', () => {
+  // issue VC for use with OID4VP
+  let verifiableCredential;
+  before(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      capabilityAgent,
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+
+    // create exchanger instance to issue VCs
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: alumniCredentialTemplate
+    }];
+    const exchangerConfig = await helpers.createExchangerConfig(
+      {capabilityAgent, zcaps, credentialTemplates, oauth2: true});
+    const exchangerId = exchangerConfig.id;
+    const exchangerRootZcap =
+      `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+
+    // create exchange to issue VC
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId,
+      exchangerRootZcap
+    });
+
+    // post empty body and get VP w/VCs in response
+    const response = await httpClient.post(exchangeId, {agent, json: {}});
+    const {verifiablePresentation: vp} = response.data;
+    ({verifiableCredential: [verifiableCredential]} = vp);
+  });
+
+  let capabilityAgent;
+  let exchangerId;
+  let exchangerRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    // require semantically-named exchanger steps
+    const steps = {
+      myStep: {
+        stepTemplate: {
+          type: 'jsonata',
+          template: `
+          {
+            "createChallenge": true,
+            "verifiablePresentationRequest": verifiablePresentationRequest,
+            "openId": openId
+          }`
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'myStep';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, steps, initialStep, oauth2: true
+    });
+    exchangerId = exchangerConfig.id;
+    exchangerRootZcap = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  });
+
+  it('should pass', async () => {
+    // create an exchange with appropriate variables for the step template
+    const exchange = {
+      // 15 minute expiry in seconds
+      ttl: 60 * 15,
+      // template variables
+      variables: {
+        verifiablePresentationRequest: {
+          query: [{
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}],
+            acceptedCryptosuites: [{cryptosuite: 'Ed25519Signature2020'}]
+          }, {
+            type: 'QueryByExample',
+            credentialQuery: [{
+              reason: 'We require a verifiable credential to pass this test',
+              example: {
+                '@context': [
+                  'https://www.w3.org/2018/credentials/v1',
+                  'https://www.w3.org/2018/credentials/examples/v1'
+                ],
+                type: 'AlumniCredential'
+              }
+            }],
+          }],
+          domain: baseUrl
+        },
+        openId: {
+          createAuthorizationRequest: 'authorizationRequest'
+        }
+      }
+    };
+    const {id: exchangeId} = await helpers.createExchange({
+      url: `${exchangerId}/exchanges`,
+      capabilityAgent, capability: exchangerRootZcap, exchange
+    });
+    const authzReqUrl = `${exchangeId}/openid/client/authorization/request`;
+
+    // `openid4vp` URL would be:
+    /*const searchParams = new URLSearchParams({
+      client_id: `${exchangeId}/openid/client/authorization/response`,
+      request_uri: authzReqUrl
+    });
+    const openid4vpUrl = 'openid4vp://authorize?' + searchParams.toString();
+    console.log('openid4vpUrl', openid4vpUrl);*/
+
+    // get authorization request
+    const {authorizationRequest} = await getAuthorizationRequest(
+      {url: authzReqUrl, agent});
+
+    should.exist(authorizationRequest);
+    should.exist(authorizationRequest.presentation_definition);
+    authorizationRequest.presentation_definition.id.should.be.a('string');
+    authorizationRequest.presentation_definition.input_descriptors.should.be
+      .an('array');
+    authorizationRequest.response_mode.should.equal('direct_post');
+    authorizationRequest.nonce.should.be.a('string');
+    // FIXME: add assertions for `authorizationRequest.presentation_definition`
+
+    // generate VPR from authorization request
+    const {verifiablePresentationRequest} = await oid4vp.toVpr(
+      {authorizationRequest});
+
+    // VPR should be the same as the one from the exchange, modulo changes
+    // comply with OID4VP spec
+    const expectedVpr = {
+      query: [{
+        type: 'DIDAuthentication',
+        // no OID4VP support for accepted DID methods at this time
+        acceptedCryptosuites: [{cryptosuite: 'Ed25519Signature2020'}]
+      }, {
+        type: 'QueryByExample',
+        credentialQuery: [{
+          reason: 'We require a verifiable credential to pass this test',
+          example: {
+            '@context': [
+              'https://www.w3.org/2018/credentials/v1',
+              'https://www.w3.org/2018/credentials/examples/v1'
+            ],
+            type: 'AlumniCredential'
+          }
+        }]
+      }],
+      // OID4VP requires this to be the authz response URL
+      domain: authorizationRequest.response_uri,
+      // challenge should be set to authz nonce
+      challenge: authorizationRequest.nonce
+    };
+    verifiablePresentationRequest.should.deep.equal(expectedVpr);
+
+    // generate VP
+    const {domain, challenge} = verifiablePresentationRequest;
+    const {verifiablePresentation, did} = await helpers.createDidAuthnVP(
+      {domain, challenge, verifiableCredential});
+
+    // send authorization response
+    const {
+      result, presentationSubmission
+    } = await oid4vp.sendAuthorizationResponse({
+      verifiablePresentation, authorizationRequest, agent
+    });
+    // should be only an optional `redirect_uri` in the response
+    should.exist(result);
+    //should.exist(result.redirect_uri);
+
+    // exchange should be complete and contain the VP and open ID results
+    // exchange state should be complete
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+        should.exist(exchange?.variables?.results?.myStep);
+        should.exist(
+          exchange?.variables?.results?.myStep?.verifiablePresentation);
+        exchange?.variables?.results?.myStep.did.should.equal(did);
+        exchange.variables.results.myStep.verifiablePresentation
+          .should.deep.equal(verifiablePresentation);
+        should.exist(exchange.variables.results.myStep.openId);
+        exchange.variables.results.myStep.openId.authorizationRequest
+          .should.deep.equal(authorizationRequest);
+        exchange.variables.results.myStep.openId.presentationSubmission
+          .should.deep.equal(presentationSubmission);
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+});

--- a/test/mocha/backwards-compatibility/35-oid4vci-oid4vp.js
+++ b/test/mocha/backwards-compatibility/35-oid4vci-oid4vp.js
@@ -1,0 +1,352 @@
+/*!
+ * Copyright (c) 2022-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as helpers from './helpers.js';
+import {
+  OID4Client, oid4vp, parseCredentialOfferUrl
+} from '@digitalbazaar/oid4-client';
+import {agent} from '@bedrock/https-agent';
+import {httpClient} from '@digitalbazaar/http-client';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+const {baseUrl, didAuthnCredentialTemplate} = mockData;
+
+describe('exchanger backwards-compatibility: ' +
+  'exchange w/OID4VCI delivery + OID4VP VC requirement', () => {
+  let capabilityAgent;
+
+  // provision a VC to use in the workflow below
+  let verifiableCredential;
+  let did;
+  let signer;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: didAuthnCredentialTemplate
+    }];
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        createChallenge: true,
+        verifiablePresentationRequest: {
+          query: {
+            type: 'DIDAuthentication',
+            acceptedMethods: [{method: 'key'}]
+          },
+          domain: baseUrl
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
+      oauth2: true
+    });
+    const workflowId = exchangerConfig.id;
+    const workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
+
+    // use workflow to provision verifiable credential
+    const credentialId = `urn:uuid:${uuid()}`;
+    const {exchangeId} = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId: workflowId,
+      exchangerRootZcap: workflowRootZcap
+    });
+
+    // generate VP
+    ({did, signer} = await helpers.createDidProofSigner());
+    const {verifiablePresentation} = await helpers.createDidAuthnVP({
+      domain: baseUrl,
+      challenge: exchangeId.slice(exchangeId.lastIndexOf('/') + 1),
+      did, signer
+    });
+
+    // post VP to get VP w/VC in response
+    const response = await httpClient.post(
+      exchangeId, {agent, json: {verifiablePresentation}});
+    const {verifiablePresentation: vp} = response.data;
+    verifiableCredential = vp.verifiableCredential[0];
+  });
+
+  // provision workflow that will require the provisioned VC above
+  let workflowId;
+  let workflowRootZcap;
+  beforeEach(async () => {
+    const deps = await helpers.provisionDependencies();
+    const {
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    } = deps;
+    ({capabilityAgent} = deps);
+
+    // create exchanger instance w/ oauth2-based authz
+    const zcaps = {
+      issue: exchangerIssueZcap,
+      credentialStatus: exchangerCredentialStatusZcap,
+      createChallenge: exchangerCreateChallengeZcap,
+      verifyPresentation: exchangerVerifyPresentationZcap
+    };
+    const credentialTemplates = [{
+      type: 'jsonata',
+      template: didAuthnCredentialTemplate
+    }];
+    // require semantically-named exchanger steps
+    const steps = {
+      // DID Authn step
+      didAuthn: {
+        stepTemplate: {
+          type: 'jsonata',
+          template: `
+          {
+            "createChallenge": true,
+            "verifiablePresentationRequest": verifiablePresentationRequest,
+            "openId": {
+              "createAuthorizationRequest": "authorizationRequest",
+              "client_id_scheme": "redirect_uri",
+              "client_id": globals.exchanger.id &
+                "/exchanges/" &
+                globals.exchange.id &
+                "/openid/client/authorization/response"
+            }
+          }`
+        }
+      }
+    };
+    // set initial step
+    const initialStep = 'didAuthn';
+    const exchangerConfig = await helpers.createExchangerConfig({
+      capabilityAgent, zcaps, credentialTemplates, steps, initialStep,
+      oauth2: true
+    });
+    workflowId = exchangerConfig.id;
+    workflowRootZcap = `urn:zcap:root:${encodeURIComponent(workflowId)}`;
+  });
+
+  it('should pass w/ pre-authorized code flow', async () => {
+    // pre-authorized flow, issuer-initiated
+    const credentialId = `urn:uuid:${uuid()}`;
+    const vpr = {
+      query: [{
+        type: 'DIDAuthentication',
+        acceptedMethods: [{method: 'key'}],
+        acceptedCryptosuites: [{cryptosuite: 'Ed25519Signature2020'}]
+      }, {
+        type: 'QueryByExample',
+        credentialQuery: [{
+          reason: 'We require a verifiable credential to pass this test',
+          example: {
+            '@context': [
+              'https://www.w3.org/2018/credentials/v1',
+              'https://www.w3.org/2018/credentials/examples/v1'
+            ],
+            type: 'UniversityDegreeCredential'
+          }
+        }]
+      }],
+      domain: baseUrl
+    };
+    const {
+      exchangeId,
+      openIdUrl: issuanceUrl
+    } = await helpers.createCredentialOffer({
+      // local target user
+      userId: 'urn:uuid:01cc3771-7c51-47ab-a3a3-6d34b47ae3c4',
+      credentialDefinition: mockData.credentialDefinition,
+      credentialId,
+      preAuthorized: true,
+      userPinRequired: false,
+      capabilityAgent,
+      exchangerId: workflowId,
+      exchangerRootZcap: workflowRootZcap,
+      variables: {
+        credentialId,
+        verifiablePresentationRequest: vpr,
+        openId: {
+          createAuthorizationRequest: 'authorizationRequest'
+        }
+      }
+    });
+    const chapiRequest = {OID4VC: issuanceUrl};
+    // CHAPI could potentially be used to deliver the URL to a native app
+    // that registered a "claimed URL" of `https://myapp.examples/ch`
+    // like so:
+    const claimedUrlFromChapi = 'https://myapp.example/ch?request=' +
+      encodeURIComponent(JSON.stringify(chapiRequest));
+    const parsedClaimedUrl = new URL(claimedUrlFromChapi);
+    const parsedChapiRequest = JSON.parse(
+      parsedClaimedUrl.searchParams.get('request'));
+    const offer = parseCredentialOfferUrl({url: parsedChapiRequest.OID4VC});
+
+    // wallet / client gets access token
+    const client = await OID4Client.fromCredentialOffer({offer, agent});
+
+    // wallet / client attempts to receive credential, should receive a
+    // `presentation_required` error with an authorization request
+    let error;
+    try {
+      await client.requestCredential({
+        credentialDefinition: mockData.credentialDefinition,
+        did,
+        didProofSigner: signer,
+        agent
+      });
+    } catch(e) {
+      error = e;
+    }
+    should.exist(error);
+    should.exist(error.cause);
+    error.cause.status.should.equal(400);
+    error.cause.data.error.should.equal('presentation_required');
+    should.exist(error.cause.data.authorization_request);
+
+    // wallet / client responds to `authorization_request` by performing
+    // OID4VP:
+    let verifiablePresentation;
+    {
+      // generate VPR from authorization request
+      const {
+        cause: {data: {authorization_request: authorizationRequest}}
+      } = error;
+      const {verifiablePresentationRequest} = await oid4vp.toVpr(
+        {authorizationRequest});
+
+      // VPR should be the same as the one from the exchange, modulo changes
+      // comply with OID4VP spec
+      const expectedVpr = {
+        query: [{
+          type: 'DIDAuthentication',
+          // no OID4VP support for accepted DID methods at this time
+          acceptedCryptosuites: [{cryptosuite: 'Ed25519Signature2020'}]
+        }, {
+          type: 'QueryByExample',
+          credentialQuery: [{
+            reason: 'We require a verifiable credential to pass this test',
+            example: {
+              '@context': [
+                'https://www.w3.org/2018/credentials/v1',
+                'https://www.w3.org/2018/credentials/examples/v1'
+              ],
+              type: 'UniversityDegreeCredential'
+            }
+          }]
+        }],
+        // OID4VP requires this to be the authz response URL
+        domain: authorizationRequest.response_uri,
+        // challenge should be set to authz nonce
+        challenge: authorizationRequest.nonce
+      };
+      verifiablePresentationRequest.should.deep.equal(expectedVpr);
+
+      // generate VP
+      const {domain, challenge} = verifiablePresentationRequest;
+      ({verifiablePresentation} = await helpers.createDidAuthnVP({
+        domain, challenge,
+        did, signer, verifiableCredential
+      }));
+
+      // send authorization response
+      const {
+        result, presentationSubmission
+      } = await oid4vp.sendAuthorizationResponse({
+        verifiablePresentation, authorizationRequest, agent
+      });
+      should.exist(result);
+
+      // exchange should be `active` and contain the VP and open ID results
+      {
+        let err;
+        try {
+          const {exchange} = await helpers.getExchange(
+            {id: exchangeId, capabilityAgent});
+          should.exist(exchange?.state);
+          exchange.state.should.equal('active');
+          should.exist(exchange?.variables?.results?.didAuthn);
+          should.exist(
+            exchange?.variables?.results?.didAuthn?.verifiablePresentation);
+          exchange?.variables?.results?.didAuthn.did.should.equal(did);
+          exchange.variables.results.didAuthn.verifiablePresentation
+            .should.deep.equal(verifiablePresentation);
+          should.exist(exchange.variables.results.didAuthn.openId);
+          exchange.variables.results.didAuthn.openId.authorizationRequest
+            .should.deep.equal(authorizationRequest);
+          exchange.variables.results.didAuthn.openId.presentationSubmission
+            .should.deep.equal(presentationSubmission);
+        } catch(error) {
+          err = error;
+        }
+        should.not.exist(err);
+      }
+    }
+
+    // wallet / client attempts to receive credential now that OID4VP is done
+    let result;
+    error = undefined;
+    try {
+      result = await client.requestCredential({
+        credentialDefinition: mockData.credentialDefinition,
+        did,
+        didProofSigner: signer,
+        agent
+      });
+    } catch(e) {
+      error = e;
+    }
+    should.not.exist(error);
+    should.exist(result);
+    result.should.include.keys(['format', 'credential']);
+    result.format.should.equal('ldp_vc');
+    // ensure credential subject ID matches generated DID
+    should.exist(result.credential?.credentialSubject?.id);
+    result.credential.credentialSubject.id.should.equal(did);
+    // ensure VC ID matches
+    should.exist(result.credential.id);
+    result.credential.id.should.equal(credentialId);
+
+    // exchange should be complete and contain the VP and original VC
+    {
+      let err;
+      try {
+        const {exchange} = await helpers.getExchange(
+          {id: exchangeId, capabilityAgent});
+        should.exist(exchange?.state);
+        exchange.state.should.equal('complete');
+        should.exist(exchange?.variables?.results?.didAuthn);
+        should.exist(
+          exchange?.variables?.results?.didAuthn?.verifiablePresentation);
+        exchange?.variables?.results?.didAuthn.did.should.equal(did);
+        exchange.variables.results.didAuthn.verifiablePresentation
+          .should.deep.equal(verifiablePresentation);
+      } catch(error) {
+        err = error;
+      }
+      should.not.exist(err);
+    }
+  });
+});

--- a/test/mocha/backwards-compatibility/helpers.js
+++ b/test/mocha/backwards-compatibility/helpers.js
@@ -1,0 +1,726 @@
+/*!
+ * Copyright (c) 2019-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as bedrock from '@bedrock/core';
+import * as Ed25519Multikey from '@digitalbazaar/ed25519-multikey';
+import {
+  generateKeyPair as _generateKeyPair,
+  exportJWK,
+  importJWK,
+  SignJWT
+} from 'jose';
+import {
+  createPresentation, defaultDocumentLoader, signPresentation
+} from '@digitalbazaar/vc';
+import {KeystoreAgent, KmsClient} from '@digitalbazaar/webkms-client';
+import {agent} from '@bedrock/https-agent';
+import {CapabilityAgent} from '@digitalbazaar/webkms-client';
+import {decodeList} from '@digitalbazaar/vc-status-list';
+import {didIo} from '@bedrock/did-io';
+import {driver} from '@digitalbazaar/did-method-key';
+import {Ed25519Signature2020} from '@digitalbazaar/ed25519-signature-2020';
+import {EdvClient} from '@digitalbazaar/edv-client';
+import {generateId} from 'bnid';
+import {getAppIdentity} from '@bedrock/app-identity';
+import {httpClient} from '@digitalbazaar/http-client';
+import {httpsAgent} from '@bedrock/https-agent';
+import {v4 as uuid} from 'uuid';
+import {ZcapClient} from '@digitalbazaar/ezcap';
+
+import {mockData} from './mock.data.js';
+
+const didKeyDriver = driver();
+const edvBaseUrl = `${mockData.baseUrl}/edvs`;
+const kmsBaseUrl = `${mockData.baseUrl}/kms`;
+
+const FIVE_MINUTES = 1000 * 60 * 5;
+
+// create document loader with contexts for VCs from `mock.data.js`
+const contexts = new Map();
+contexts.set(
+  'https://www.w3.org/2018/credentials/examples/v1', mockData.examplesContext);
+
+const documentLoader = async url => {
+  const document = contexts.get(url);
+  if(document !== undefined) {
+    return {
+      contextUrl: null,
+      documentUrl: url,
+      document,
+      tag: 'static'
+    };
+  }
+  return defaultDocumentLoader(url);
+};
+
+// Note: `userId` left here to model how systems would potentially integrate
+// with VC-API exchange services
+export async function createCredentialOffer({
+  /*userId, */
+  credentialDefinition, credentialId, variables,
+  preAuthorized, userPinRequired = false,
+  capabilityAgent, exchangerId, exchangerRootZcap,
+  openId = true, openIdKeyPair
+} = {}) {
+  // first, create an exchange with variables based on the local user ID;
+  // indicate that OID4VCI delivery is permitted
+  const exchange = {
+    // 15 minute expiry in seconds
+    ttl: 60 * 15,
+    // template variables
+    variables: variables ? {
+      issuanceDate: (new Date()).toISOString(),
+      ...variables
+    } : {
+      credentialId: credentialId ?? `urn:uuid:${uuid()}`,
+      issuanceDate: (new Date()).toISOString()
+    }
+  };
+  let offer;
+  if(openId) {
+    // build OID4VCI oauth2 config
+    const oauth2 = {};
+    if(openIdKeyPair) {
+      oauth2.keyPair = openIdKeyPair;
+    } else {
+      oauth2.generateKeyPair = {algorithm: 'ES256'};
+    }
+    if(!Array.isArray(credentialDefinition)) {
+      credentialDefinition = [credentialDefinition];
+    }
+    const expectedCredentialRequests = credentialDefinition.map(
+      credential_definition => ({format: 'ldp_vc', credential_definition}));
+    exchange.openId = {expectedCredentialRequests, oauth2};
+
+    // start building OID4VCI credential offer
+    offer = {
+      credential_issuer: '',
+      // FIXME: use `credentials_supported` string IDs instead
+      credentials: credentialDefinition.map(
+        credential_definition => ({format: 'ldp_vc', credential_definition})),
+      grants: {}
+    };
+
+    if(preAuthorized) {
+      exchange.openId.preAuthorizedCode = await generateRandom();
+      const grant = {'pre-authorized_code': exchange.openId.preAuthorizedCode};
+      offer.grants['urn:ietf:params:oauth:grant-type:pre-authorized_code'] =
+        grant;
+      // `user_pin_required` default is `false` per the OID4VCI spec
+      if(userPinRequired) {
+        grant.user_pin_required = true;
+      }
+    } else {
+      offer.grants.authorization_code = {
+        // FIXME: implement
+        issuer_state: 'eyJhbGciOiJSU0Et...FYUaBy'
+      };
+    }
+  }
+  const {id: exchangeId} = await createExchange({
+    url: `${exchangerId}/exchanges`,
+    capabilityAgent, capability: exchangerRootZcap, exchange
+  });
+
+  const result = {exchangeId};
+
+  if(openId) {
+    offer.credential_issuer = exchangeId;
+    const searchParams = new URLSearchParams();
+    searchParams.set('credential_offer', JSON.stringify(offer));
+    result.openIdUrl = `openid-credential-offer://?${searchParams}`;
+  }
+
+  return result;
+}
+
+export async function createConfig({
+  serviceType, url, capabilityAgent, ipAllowList, meterId, zcaps,
+  configOptions = {}, oauth2 = false
+} = {}) {
+  if(!meterId) {
+    // create a meter
+    ({id: meterId} = await createMeter({capabilityAgent, serviceType}));
+  }
+
+  // create service object
+  const config = {
+    sequence: 0,
+    controller: capabilityAgent.id,
+    meterId,
+    ...configOptions
+  };
+  if(ipAllowList) {
+    config.ipAllowList = ipAllowList;
+  }
+  if(zcaps) {
+    config.zcaps = zcaps;
+  }
+  if(oauth2) {
+    const {baseUri} = bedrock.config.server;
+    config.authorization = {
+      oauth2: {
+        issuerConfigUrl: `${baseUri}${mockData.oauth2IssuerConfigRoute}`
+      }
+    };
+  }
+
+  const zcapClient = createZcapClient({capabilityAgent});
+  const response = await zcapClient.write({url, json: config});
+  return response.data;
+}
+
+export async function createExchangerConfig({
+  capabilityAgent, ipAllowList, meterId, zcaps, credentialTemplates,
+  steps, initialStep, oauth2 = false,
+  configOptions = {credentialTemplates, steps, initialStep}
+} = {}) {
+  const url = `${mockData.baseUrl}/exchangers`;
+  return createConfig({
+    serviceType: 'vc-exchanger',
+    url, capabilityAgent, ipAllowList, meterId, zcaps, configOptions, oauth2
+  });
+}
+
+export async function createIssuerConfig({
+  capabilityAgent, ipAllowList, meterId, zcaps,
+  statusListOptions, oauth2 = false
+} = {}) {
+  const url = `${mockData.baseUrl}/issuers`;
+  // issuer-specific options
+  const configOptions = {
+    issueOptions: {
+      suiteName: 'Ed25519Signature2020'
+    },
+    statusListOptions
+  };
+  return createConfig({
+    serviceType: 'vc-issuer',
+    url, capabilityAgent, ipAllowList, meterId, zcaps, configOptions, oauth2
+  });
+}
+
+export async function createMeter({capabilityAgent, serviceType} = {}) {
+  // create signer using the application's capability invocation key
+  const {keys: {capabilityInvocationKey}} = getAppIdentity();
+
+  const zcapClient = new ZcapClient({
+    agent: httpsAgent,
+    invocationSigner: capabilityInvocationKey.signer(),
+    SuiteClass: Ed25519Signature2020
+  });
+
+  // create a meter
+  const meterService = `${bedrock.config.server.baseUri}/meters`;
+  let meter = {
+    controller: capabilityAgent.id,
+    product: {
+      // mock ID for service type
+      id: mockData.productIdMap.get(serviceType)
+    }
+  };
+  ({data: {meter}} = await zcapClient.write({url: meterService, json: meter}));
+
+  // return full meter ID
+  const {id} = meter;
+  return {id: `${meterService}/${id}`};
+}
+
+export async function createVerifierConfig({
+  capabilityAgent, ipAllowList, meterId, zcaps, oauth2 = false
+} = {}) {
+  const url = `${mockData.baseUrl}/verifiers`;
+  return createConfig({
+    serviceType: 'vc-verifier',
+    url, capabilityAgent, ipAllowList, meterId, zcaps, oauth2
+  });
+}
+
+export async function generateKeyPair({algorithm = 'EdDSA'} = {}) {
+  // generate keypair for AS
+  const keyPair = await _generateKeyPair(algorithm, {extractable: true});
+  const [privateKeyJwk, publicKeyJwk] = await Promise.all([
+    exportJWK(keyPair.privateKey),
+    exportJWK(keyPair.publicKey),
+  ]);
+  return {privateKeyJwk, publicKeyJwk};
+}
+
+export async function getConfig({id, capabilityAgent, accessToken}) {
+  if(accessToken) {
+    // do OAuth2
+    const {data} = await httpClient.get(id, {
+      agent: httpsAgent,
+      headers: {
+        authorization: `Bearer ${accessToken}`
+      }
+    });
+    return data;
+  }
+  if(!capabilityAgent) {
+    throw new Error('Either "capabilityAgent" or "accessToken" is required.');
+  }
+  // do zcap
+  const zcapClient = createZcapClient({capabilityAgent});
+  const {data} = await zcapClient.read({url: id});
+  return data;
+}
+
+export async function getOAuth2AccessToken({
+  configId, action, target, exp, iss, nbf, typ = 'at+jwt'
+}) {
+  const scope = `${action}:${target}`;
+  const builder = new SignJWT({scope})
+    .setProtectedHeader({alg: 'EdDSA', typ})
+    .setIssuer(iss ?? mockData.oauth2Config.issuer)
+    .setAudience(configId);
+  if(exp !== undefined) {
+    builder.setExpirationTime(exp);
+  } else {
+    // default to 5 minute expiration time
+    builder.setExpirationTime('5m');
+  }
+  if(nbf !== undefined) {
+    builder.setNotBefore(nbf);
+  }
+  const key = await importJWK({...mockData.ed25519KeyPair, alg: 'EdDSA'});
+  return builder.sign(key);
+}
+
+export async function createDidAuthnVP({
+  domain, challenge, verifiableCredential, did, signer
+}) {
+  if(!(did && signer)) {
+    ({did, signer} = await createDidProofSigner());
+  }
+  const presentation = createPresentation({holder: did});
+  if(verifiableCredential) {
+    presentation.verifiableCredential = verifiableCredential;
+  }
+  const verifiablePresentation = await signPresentation({
+    suite: new Ed25519Signature2020({signer}),
+    presentation, domain, challenge,
+    documentLoader
+  });
+  return {verifiablePresentation, did};
+}
+
+export async function createDidProofSigner() {
+  const {didDocument, methodFor} = await didKeyDriver.generate();
+  const authenticationKeyPair = methodFor({purpose: 'authentication'});
+  const keyPair = await Ed25519Multikey.from(authenticationKeyPair);
+  return {did: didDocument.id, signer: keyPair.signer()};
+}
+
+export async function createExchange({
+  url, capabilityAgent, capability, exchange
+}) {
+  const zcapClient = createZcapClient({capabilityAgent});
+  const response = await zcapClient.write({url, json: exchange, capability});
+  const exchangeId = response.headers.get('location');
+  return {id: exchangeId};
+}
+
+export async function getExchange({id, capabilityAgent, accessToken} = {}) {
+  if(accessToken) {
+    // do OAuth2
+    const {data} = await httpClient.get(id, {
+      agent: httpsAgent,
+      headers: {
+        authorization: `Bearer ${accessToken}`
+      }
+    });
+    return data;
+  }
+  if(!capabilityAgent) {
+    throw new Error('Either "capabilityAgent" or "accessToken" is required.');
+  }
+  // do zcap
+  const zcapClient = createZcapClient({capabilityAgent});
+  // assume root zcap for associated exchanger
+  const exchangerId = id.slice(0, id.lastIndexOf('/exchanges/'));
+  const capability = `urn:zcap:root:${encodeURIComponent(exchangerId)}`;
+  const {data} = await zcapClient.read({url: id, capability});
+  return data;
+}
+
+export async function createEdv({
+  capabilityAgent, keystoreAgent, keyAgreementKey, hmac, meterId
+}) {
+  if(!meterId) {
+    // create a meter for the keystore
+    ({id: meterId} = await createMeter({
+      capabilityAgent, serviceType: 'edv'
+    }));
+  }
+
+  if(!(keyAgreementKey && hmac) && keystoreAgent) {
+    // create KAK and HMAC keys for edv config
+    ([keyAgreementKey, hmac] = await Promise.all([
+      keystoreAgent.generateKey({type: 'keyAgreement'}),
+      keystoreAgent.generateKey({type: 'hmac'})
+    ]));
+  }
+
+  // create edv
+  const newEdvConfig = {
+    sequence: 0,
+    controller: capabilityAgent.id,
+    keyAgreementKey: {id: keyAgreementKey.id, type: keyAgreementKey.type},
+    hmac: {id: hmac.id, type: hmac.type},
+    meterId
+  };
+
+  const edvConfig = await EdvClient.createEdv({
+    config: newEdvConfig,
+    httpsAgent,
+    invocationSigner: capabilityAgent.getSigner(),
+    url: edvBaseUrl
+  });
+
+  const edvClient = new EdvClient({
+    id: edvConfig.id,
+    keyResolver,
+    keyAgreementKey,
+    hmac,
+    httpsAgent
+  });
+
+  return {edvClient, edvConfig, hmac, keyAgreementKey};
+}
+
+export async function createKeystore({
+  capabilityAgent, ipAllowList, meterId,
+  kmsModule = 'ssm-v1'
+}) {
+  if(!meterId) {
+    // create a meter for the keystore
+    ({id: meterId} = await createMeter(
+      {capabilityAgent, serviceType: 'webkms'}));
+  }
+
+  // create keystore
+  const config = {
+    sequence: 0,
+    controller: capabilityAgent.id,
+    meterId,
+    kmsModule
+  };
+  if(ipAllowList) {
+    config.ipAllowList = ipAllowList;
+  }
+
+  return KmsClient.createKeystore({
+    url: `${kmsBaseUrl}/keystores`,
+    config,
+    invocationSigner: capabilityAgent.getSigner(),
+    httpsAgent
+  });
+}
+
+export async function createKeystoreAgent({capabilityAgent, ipAllowList}) {
+  let err;
+  let keystore;
+  try {
+    keystore = await createKeystore({capabilityAgent, ipAllowList});
+  } catch(e) {
+    err = e;
+  }
+  assertNoError(err);
+
+  // create kmsClient only required because we need to use httpsAgent
+  // that accepts self-signed certs used in test suite
+  const kmsClient = new KmsClient({httpsAgent});
+  const keystoreAgent = new KeystoreAgent({
+    capabilityAgent,
+    keystoreId: keystore.id,
+    kmsClient
+  });
+
+  return keystoreAgent;
+}
+
+export function createZcapClient({
+  capabilityAgent, delegationSigner, invocationSigner
+}) {
+  const signer = capabilityAgent && capabilityAgent.getSigner();
+  return new ZcapClient({
+    agent: httpsAgent,
+    invocationSigner: invocationSigner || signer,
+    delegationSigner: delegationSigner || signer,
+    SuiteClass: Ed25519Signature2020
+  });
+}
+
+export async function delegate({
+  capability, controller, invocationTarget, expires, allowedActions,
+  delegator
+}) {
+  const zcapClient = createZcapClient({capabilityAgent: delegator});
+  expires = expires || (capability && capability.expires) ||
+    new Date(Date.now() + FIVE_MINUTES).toISOString().slice(0, -5) + 'Z';
+  return zcapClient.delegate({
+    capability, controller, expires, invocationTarget, allowedActions
+  });
+}
+
+export function generateRandom() {
+  // 128-bit random number, base58 multibase + multihash encoded
+  return generateId({
+    bitLength: 128,
+    encoding: 'base58',
+    multibase: true,
+    multihash: true
+  });
+}
+
+export async function getCredentialStatus({verifiableCredential}) {
+  // get SLC for the VC
+  const {credentialStatus} = verifiableCredential;
+  if(Array.isArray(credentialStatus)) {
+    throw new Error('Multiple credential statuses not supported.');
+  }
+  let slcUrl;
+  let statusListIndexProperty;
+  if(credentialStatus.type === 'RevocationList2020Status') {
+    slcUrl = credentialStatus.revocationListCredential;
+    statusListIndexProperty = 'revocationListIndex';
+  } else {
+    slcUrl = credentialStatus.statusListCredential;
+    statusListIndexProperty = 'statusListIndex';
+  }
+  if(!slcUrl) {
+    throw new Error('Status list credential missing from credential status.');
+  }
+  const {data: slc} = await httpClient.get(slcUrl, {agent: httpsAgent});
+
+  const {encodedList} = slc.credentialSubject;
+  const list = await decodeList({encodedList});
+  const statusListIndex = parseInt(
+    credentialStatus[statusListIndexProperty], 10);
+  const status = list.getStatus(statusListIndex);
+  return {status, statusListCredential: slcUrl};
+}
+
+export async function provisionDependencies() {
+  const secret = '53ad64ce-8e1d-11ec-bb12-10bf48838a41';
+  const handle = 'test';
+  const capabilityAgent = await CapabilityAgent.fromSecret({secret, handle});
+
+  // create keystore for capability agent
+  const keystoreAgent = await createKeystoreAgent({capabilityAgent});
+
+  // FIXME: a verifier instance isn't necessary for single-step exchanges or
+  // exchanges that do not do any DID Authn, but this method provisions a
+  // verifier anyway; this could be parameterized later to better test when
+  // this is needed and when it isn't
+  const [
+    {
+      issuerConfig,
+      exchangerIssueZcap,
+      exchangerCredentialStatusZcap
+    },
+    {
+      verifierConfig,
+      exchangerCreateChallengeZcap,
+      exchangerVerifyPresentationZcap
+    }
+  ] = await Promise.all([
+    provisionIssuer({capabilityAgent, keystoreAgent}),
+    provisionVerifier({capabilityAgent, keystoreAgent})
+  ]);
+
+  return {
+    issuerConfig, exchangerIssueZcap, exchangerCredentialStatusZcap,
+    verifierConfig, exchangerCreateChallengeZcap,
+    exchangerVerifyPresentationZcap,
+    capabilityAgent
+  };
+}
+
+export async function provisionIssuer({capabilityAgent, keystoreAgent}) {
+  // generate key for signing VCs (make it a did:key DID for simplicity)
+  const assertionMethodKey = await keystoreAgent.generateKey({
+    type: 'asymmetric',
+    publicAliasTemplate: 'did:key:{publicKeyMultibase}#{publicKeyMultibase}'
+  });
+
+  // create EDV for storage (creating hmac and kak in the process)
+  const {
+    edvConfig,
+    hmac,
+    keyAgreementKey
+  } = await createEdv({capabilityAgent, keystoreAgent});
+
+  // get service agent to delegate to
+  const issuerServiceAgentUrl =
+    `${mockData.baseUrl}/service-agents/${encodeURIComponent('vc-issuer')}`;
+  const {data: issuerServiceAgent} = await httpClient.get(
+    issuerServiceAgentUrl, {agent});
+
+  // delegate edv, hmac, and key agreement key zcaps to service agent
+  const {id: edvId} = edvConfig;
+  const zcaps = {};
+  zcaps.edv = await delegate({
+    controller: issuerServiceAgent.id,
+    delegator: capabilityAgent,
+    invocationTarget: edvId
+  });
+  const {keystoreId} = keystoreAgent;
+  zcaps.hmac = await delegate({
+    capability: `urn:zcap:root:${encodeURIComponent(keystoreId)}`,
+    controller: issuerServiceAgent.id,
+    invocationTarget: hmac.id,
+    delegator: capabilityAgent
+  });
+  zcaps.keyAgreementKey = await delegate({
+    capability: `urn:zcap:root:${encodeURIComponent(keystoreId)}`,
+    controller: issuerServiceAgent.id,
+    invocationTarget: keyAgreementKey.kmsId,
+    delegator: capabilityAgent
+  });
+  zcaps.assertionMethod = await delegate({
+    capability: `urn:zcap:root:${encodeURIComponent(keystoreId)}`,
+    controller: issuerServiceAgent.id,
+    invocationTarget: assertionMethodKey.kmsId,
+    delegator: capabilityAgent
+  });
+
+  // create issuer instance w/ oauth2-based authz
+  const issuerConfig = await createIssuerConfig(
+    {capabilityAgent, zcaps, oauth2: true});
+  const {id: issuerId} = issuerConfig;
+  const issuerRootZcap = `urn:zcap:root:${encodeURIComponent(issuerId)}`;
+
+  // insert examples context
+  const examplesContextId = 'https://www.w3.org/2018/credentials/examples/v1';
+  const {examplesContext} = mockData;
+  const client = createZcapClient({capabilityAgent});
+  const url = `${issuerId}/contexts`;
+  await client.write({
+    url, json: {id: examplesContextId, context: examplesContext},
+    capability: issuerRootZcap
+  });
+
+  // insert prc context
+  const prcContextId = 'https://w3id.org/citizenship/v1';
+  const {prcCredentialContext} = mockData;
+  await client.write({
+    url, json: {id: prcContextId, context: prcCredentialContext},
+    capability: issuerRootZcap
+  });
+
+  // delegate issuer root zcap to exchanger service
+  const exchangerServiceAgentUrl =
+    `${mockData.baseUrl}/service-agents/${encodeURIComponent('vc-exchanger')}`;
+  const {data: exchangerServiceAgent} = await httpClient.get(
+    exchangerServiceAgentUrl, {agent});
+
+  // zcap to issue a credential
+  const exchangerIssueZcap = await delegate({
+    capability: issuerRootZcap,
+    controller: exchangerServiceAgent.id,
+    invocationTarget: `${issuerId}/credentials/issue`,
+    delegator: capabilityAgent
+  });
+
+  // zcap to set the status of a credential
+  const exchangerCredentialStatusZcap = await delegate({
+    capability: issuerRootZcap,
+    controller: exchangerServiceAgent.id,
+    invocationTarget: `${issuerId}/credentials/status`,
+    delegator: capabilityAgent
+  });
+
+  return {issuerConfig, exchangerIssueZcap, exchangerCredentialStatusZcap};
+}
+
+export async function provisionVerifier({capabilityAgent, keystoreAgent}) {
+  // create EDV for storage (creating hmac and kak in the process)
+  const {
+    edvConfig,
+    hmac,
+    keyAgreementKey
+  } = await createEdv({capabilityAgent, keystoreAgent});
+
+  // get service agent to delegate to
+  const veriferServiceAgentUrl =
+    `${mockData.baseUrl}/service-agents/${encodeURIComponent('vc-verifier')}`;
+  const {data: veriferServiceAgent} = await httpClient.get(
+    veriferServiceAgentUrl, {agent});
+
+  // delegate edv, hmac, and key agreement key zcaps to service agent
+  const {id: edvId} = edvConfig;
+  const zcaps = {};
+  zcaps.edv = await delegate({
+    controller: veriferServiceAgent.id,
+    delegator: capabilityAgent,
+    invocationTarget: edvId
+  });
+  const {keystoreId} = keystoreAgent;
+  zcaps.hmac = await delegate({
+    capability: `urn:zcap:root:${encodeURIComponent(keystoreId)}`,
+    controller: veriferServiceAgent.id,
+    invocationTarget: hmac.id,
+    delegator: capabilityAgent
+  });
+  zcaps.keyAgreementKey = await delegate({
+    capability: `urn:zcap:root:${encodeURIComponent(keystoreId)}`,
+    controller: veriferServiceAgent.id,
+    invocationTarget: keyAgreementKey.kmsId,
+    delegator: capabilityAgent
+  });
+
+  // create verifer instance w/ oauth2-based authz
+  const verifierConfig = await createVerifierConfig(
+    {capabilityAgent, zcaps, oauth2: true});
+  const {id: verifierId} = verifierConfig;
+  const verifierRootZcap = `urn:zcap:root:${encodeURIComponent(verifierId)}`;
+
+  // delegate verifier root zcap to exchanger service
+  const exchangerServiceAgentUrl =
+    `${mockData.baseUrl}/service-agents/${encodeURIComponent('vc-exchanger')}`;
+  const {data: exchangerServiceAgent} = await httpClient.get(
+    exchangerServiceAgentUrl, {agent});
+
+  // zcap to create a challenge
+  const exchangerCreateChallengeZcap = await delegate({
+    capability: verifierRootZcap,
+    controller: exchangerServiceAgent.id,
+    invocationTarget: `${verifierId}/challenges`,
+    delegator: capabilityAgent
+  });
+
+  // zcap to verify a presentation
+  const exchangerVerifyPresentationZcap = await delegate({
+    capability: verifierRootZcap,
+    controller: exchangerServiceAgent.id,
+    invocationTarget: `${verifierId}/presentations/verify`,
+    delegator: capabilityAgent
+  });
+
+  return {
+    verifierConfig,
+    exchangerCreateChallengeZcap,
+    exchangerVerifyPresentationZcap
+  };
+}
+
+export async function revokeDelegatedCapability({
+  serviceObjectId, capabilityToRevoke, invocationSigner
+}) {
+  const url = `${serviceObjectId}/zcaps/revocations/` +
+    encodeURIComponent(capabilityToRevoke.id);
+  const zcapClient = createZcapClient({invocationSigner});
+  return zcapClient.write({url, json: capabilityToRevoke});
+}
+
+async function keyResolver({id}) {
+  // support DID-based keys only
+  if(id.startsWith('did:')) {
+    return didIo.get({url: id});
+  }
+  // support HTTP-based keys; currently a requirement for WebKMS
+  const {data} = await httpClient.get(id, {agent: httpsAgent});
+  return data;
+}

--- a/test/mocha/backwards-compatibility/mock.data.js
+++ b/test/mocha/backwards-compatibility/mock.data.js
@@ -1,0 +1,345 @@
+/*!
+* Copyright (c) 2019-2024 Digital Bazaar, Inc. All rights reserved.
+*/
+import {config} from '@bedrock/core';
+
+export const mockData = {};
+
+// mock product IDs and reverse lookup for service products
+mockData.productIdMap = new Map([
+  // edv service
+  ['edv', 'urn:uuid:dbd15f08-ff67-11eb-893b-10bf48838a41'],
+  ['urn:uuid:dbd15f08-ff67-11eb-893b-10bf48838a41', 'edv'],
+  // vc-exchanger service
+  ['vc-exchanger', 'urn:uuid:146b6a5b-eade-4612-a215-1f3b5f03d648'],
+  ['urn:uuid:146b6a5b-eade-4612-a215-1f3b5f03d648', 'vc-exchanger'],
+  // vc-issuer service
+  ['vc-issuer', 'urn:uuid:66aad4d0-8ac1-11ec-856f-10bf48838a41'],
+  ['urn:uuid:66aad4d0-8ac1-11ec-856f-10bf48838a41', 'vc-issuer'],
+  // vc-verifier service
+  ['vc-verifier', 'urn:uuid:5dce95eb-d0e2-407d-b4ec-d3ced2f586d5'],
+  ['urn:uuid:5dce95eb-d0e2-407d-b4ec-d3ced2f586d5', 'vc-verifier'],
+  // webkms service
+  ['webkms', 'urn:uuid:80a82316-e8c2-11eb-9570-10bf48838a41'],
+  ['urn:uuid:80a82316-e8c2-11eb-9570-10bf48838a41', 'webkms']
+]);
+
+mockData.baseUrl = config.server.baseUri;
+
+// OpenID discovery server meta data example:
+// https://accounts.google.com/.well-known/openid-configuration
+
+// `jwks_uri` example w/RSA keys:
+// https://www.googleapis.com/oauth2/v3/certs
+
+// minimal example open ID config for testing
+mockData.oauth2IssuerConfigRoute = '/.well-known/oauth-authorization-server';
+mockData.oauth2Config = {
+  issuer: mockData.baseUrl,
+  jwks_uri: `${mockData.baseUrl}/oauth2/jwks`,
+  token_endpoint: `${mockData.baseUrl}/oauth2/token`
+};
+
+// Ed25519 and EC keys
+mockData.ed25519KeyPair = {
+  kid: '-iHGX4KWRiuX0aa3sAnhKTw7utzGI2el7HVI4LCFiJg',
+  kty: 'OKP',
+  crv: 'Ed25519',
+  d: 'ANQCyJz3mHyJGYzvAwHlUa4pHzfMhJWSHvadUYTi7Hg',
+  x: '-iHGX4KWRiuX0aa3sAnhKTw7utzGI2el7HVI4LCFiJg'
+};
+
+mockData.jwks = {
+  // Ed25519 public key matches full key pair above
+  keys: [{
+    kid: '-iHGX4KWRiuX0aa3sAnhKTw7utzGI2el7HVI4LCFiJg',
+    kty: 'OKP',
+    crv: 'Ed25519',
+    //d: 'ANQCyJz3mHyJGYzvAwHlUa4pHzfMhJWSHvadUYTi7Hg',
+    x: '-iHGX4KWRiuX0aa3sAnhKTw7utzGI2el7HVI4LCFiJg',
+    key_ops: ['verify']
+  }, {
+    kid: 'H6hWVHmpAG6mnCW6_Up2EYYZu-98-MK298t4LLsqGSM',
+    kty: 'EC',
+    crv: 'P-256',
+    x: 'H6hWVHmpAG6mnCW6_Up2EYYZu-98-MK298t4LLsqGSM',
+    y: 'iU2niSRdN77sFhdRvTifg4hcy4AmfsDSOND0_RHhcIU',
+    //d: '25f2jge6YltyS3kdXHsm3tEEbkj_fdyC6ODJAfjgem4',
+    use: 'sig'
+  }, {
+    kid: 'uApgIU7jCc8QRcm1iJR7AuYOCGVsTuY--6jvYCNsrY6naQ2TJETabttQSI33Tg5_',
+    kty: 'EC',
+    crv: 'P-384',
+    x: 'uApgIU7jCc8QRcm1iJR7AuYOCGVsTuY--6jvYCNsrY6naQ2TJETabttQSI33Tg5_',
+    y: 'rnavIz5-cIeuJDYzX-E4vwLRo7g2z96KBcGMaQ0V2KMvS-q8e2sZmLfL-O0kZf6v',
+    //d: 'BK5RZ_7qm2JhoNAfXxW-Ka6PbAJTUaK7f2Xm-c8jBkk3dpFi2d15gl_nPHnX4Nfg',
+    key_ops: ['verify']
+  }]
+};
+
+mockData.credentialTemplate = `
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "id": credentialId,
+    "type": [
+      "VerifiableCredential",
+      "UniversityDegreeCredential"
+    ],
+    "issuanceDate": issuanceDate,
+    "credentialSubject": {
+      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science and Arts"
+      }
+    }
+  }
+`;
+
+mockData.alumniCredentialTemplate = `
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "id": credentialId,
+    "type": [
+      "VerifiableCredential",
+      "AlumniCredential"
+    ],
+    "issuanceDate": issuanceDate,
+    "credentialSubject": {
+      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      "alumniOf": {
+        "name": "Example University"
+      }
+    }
+  }
+`;
+
+mockData.credentialRequestTemplate = `
+  {
+    "options": {
+      "credentialId": credentialId
+    },
+    "credential": {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "issuanceDate": issuanceDate,
+      "credentialSubject": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "degree": {
+          "type": "BachelorDegree",
+          "name": "Bachelor of Science and Arts"
+        }
+      }
+    }
+  }
+`;
+
+mockData.genericCredentialRequestTemplate = `$eval(credentialRequest)`;
+mockData.genericCredentialTemplate = `$eval(vc)`;
+
+/* eslint-disable */
+mockData.prcCredentialTemplate = `
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/citizenship/v1"
+    ],
+    "id": credentialId,
+    "type": [
+      "VerifiableCredential",
+      "PermanentResidentCard"
+    ],
+    "identifier": "83627465",
+    "name": "Permanent Resident Card",
+    "description": "Government of Utopia Permanent Resident Card.",
+    "issuanceDate": issuanceDate,
+    "credentialSubject": {
+      "id": "did:example:b34ca6cd37bbf23",
+      "type": [
+        "PermanentResident",
+        "Person"
+      ],
+      "givenName": "JANE",
+      "familyName": "SMITH",
+      "gender": "Female",
+      "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAADVCAMAAAAlzk/pAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAAJcEhZcwAADsIAAA7CARUoSoAAAAMAUExURfn6/Ovu9uPq9eru9+Tr9eDo9PX2++js9eLp9ebs9ufr9eTq9u7x+Ozv9+3w+SIgJOft9yAeICEfIvT1+i8uLyQiJaemp+nt9/f3++Tq9PT1+ejs9yglJiQhIu/y+R4cHufn7Onp7UhGR+3w9+fq8vj5++3OxOvt9ODo9fHz+dzh7OXq89/l8Pj5/ODn8tfd6eXr9vL0+T0yMNvf6eXp8e3Rx93j7kA1M+fr9nh6fuzLwHZ5fYSFhurq7yonKeDj7fHy92xrbOLo8y0qLG9ub0M4NjcqJezs8J2MgzouLOO0nunGseTn8N+vl+Tk6dng69Tb6Ons89uvljImIujDrUQzLdaoju7u8n1+gd+2nenCsj8tJ+bEse/w9Om/r9Ggh0c7OeW2ojIwMsTDxeO3ptfW2Oa6qderlOXBrt+0o7m5vOnAqN+zmsyXfuzFtea9rdyqlee7pOHh59uym9utkTs4Okw/PeLm70c3Mu3Iu+rIuzY0NeK8pk08Nr68wOO5oO7UzNGjjH5tZNCcgdilk9+wn9ahjXV4fK2wtt2ojpydoenFt9mliEE+QOjl58aMc4eJjHNMQaNvXsySd1FPUVFEQdurm+S/qeOxmt3d4ldIRCgdGo2Qls6Zhrt8ZF5MSJpmVlVAOseah0xLTL2LdtyRjcOTeWhGPeC5ooCBhGdmZ1dWWI1hVy0hHceQfuTf4i8sLc3R2bBzXl9eYd3Qz9PX4HpmXdiegcGGbtaWeG9UTePb3HRydXx7fre8xLunnKd3ac2KbbJ8Zt7Fvc+sm7iEaxsYGIhaTd/X2cnK0N27sM+lln1XTk0zLJSXnKSpsaShoquSh8SDZuTAt3BeWte2rObr92RUUdOwpGA/NpB3a8WikuOYmOGggZt/d73Dy+eulOWnjJ+jqqlkT7uRg7abkNHP0q6pq+u1nriCc5ZbSlc5MNaIg4GFjOXMxZVuZpCLjcLH0M99d4RRQbK2vYRzcOXTzq2Ee76ytc/Bv459fMRxYOipqpqRk76qqKOYmWhxaecAAFLWSURBVHjafJjPa9vYFsfLjUzlaOPVCyK7RxcmNopQgpWS8soT2GAoOGAMA9kIsusf4GijLLppKDyYlPEiouCaWZg+0kUW6SI8ug2BtJOFSci2i+miFFKYwBAIeed77tUPS565/lG3SS199D3f7zlXDwzbLpfpSW+GLgyh66V0VeVKP/HnZImSoKXTQxhY/DXlsmaXbfWRvxc/10WpuCyrhEdxeZ5852WpVa/TM16NRmOpQ2uZ1gbWA3n4iiKhQ4osBwOU1Et+Vj/T6VHCCdJL16c4COMi5SAu+g0hwacw1GsaRU9IPCbRE5AMBnMokI0YxE5ANI3PKj1cNaPEtBxKNglCCIZB519W0kKSDIcGqYW8QnpOEj6ENRMFNPrfgTBHZyNWRACkUqmUL2xDiPiAU4okFPKZHE/IwmIxtPJfLlJEAs+oLSBUS4UC05O6ypSWBGnkFWGOo40HsppBUjYMnVimL1oWJFNZutQDy0BdsRpSh8oMlLLGHGK6rvBm5Usr/nIJoXsmg3gZjzTwaDQ6S4pDKUJlUCEOHN8mTQhG5ChK1ZlOjy1C+ZC1tjzzZ9s17emzZ9uquDTTpBARRUFg+GopI7SeVQSVlYJYEqShBGl04tqSILYqrQqT4ALrxRIoUMirK2KPSElYjYuKZmrbS08Pd7/+Y/f8z9Oj+tP9lRVv37NEobro5IrH0mMjAUQ39UxtKZewIAVF7HLCUUYFcHLNIMn/SwxiGHFiyZqyVk6fn989eXJ782JC6+b2+vruz/vz+/2G53EKy2gliirid2b66tCDRdFNYVrTLmkkJDmPxCB8HoSRja2SVU0DLM74uACk2w3OLJuFLXtHO3fXLyaXQ1qDQX8wiKLhJa3J5MPu4dbp4enW6f5S3ZIsVSvpJdN6iIzVTdMs2L3BtdVpcGVlFakkktianiOJMaqz9E9Sy+bc1bbuwEAEfbz8Pi+Cwbo5v75+cnd79+rrj5WkpKzSdEvU044If+i6ySBeIgrZRHkkbYgbqo/EmXURt8ScK6t5SVQHwZsuNKEZFxLk6A464Px9v+83m/R0Hcdthj7B9AeszH8nk3+/uNtagSazAouvEB6yhZgKZKq/q/jtdKZBmEPFFl1UA8VVtHqxjgWHljQILoG3OxmOiCH0A99v9vtNlylct0lUIKG3viq1/92f1kuzMdSf4IDX4RFWxEuDy1IeUaW1nCmtCqNoUMQwZrSuGXUlZGGRObiw7KNbKqkwcN0AQjSbTQccrk9QzSYQBn4YBC6hQJnLm6/LlrRbjoO+G+ePvPIIIlakxizpxCU5lrIjShK+FfRgY2ZoVQtXTc0AGkAwkGx9iEZ0okHgkwTQwW23SRL+RDA+XDMInIA+RL9Eg+Fwcn80K6+ElEM3ObGwNKBYqU1SkMbS1NCoLMKCoJFwaYlc9OZLS3HEThc7x9EoQEmRMUBCWrhO24EmDlcXAKKg5wT8mepreHm7US/NbCMsiGcqh2ixR1RpWakiS1N95IJBFlVqGYacikQOpDrd0RMSg5N3ZzIIm37I/m4yiQsIerVbbVr0gbQIw4DgSCASZxANJ+crMzURsn+YLAiKyzNjkLS/N9SwNeWRSrykR3IYs9q6UC2d5yxb27nsN/0Bgoout8swKCrHYRrmcoOwF4xGPao3V6L8Gk3uG96M2mI9YHYWRECRWia36lZWEfbIcgqyuLgYgxTbCEJ/ikTEIDqD7Ez6zTDsc2G5lFd+05FOlxYBnd8M/EEQRpDEQY5BlMHl7sxxERwmOEgTjGncFxOzx/1dBXDWI6qyQGJjh8iNRP+bCUXIzZSODaVhbE0okHD6ZA/ELkzBBkHukkLEAcAgCEejkdNq80+gyS/DmyMvzyHYogKCsNsxb0qwTE+szxi2cqUljFmNvZTn4D0xY9i/v4gGdF5scsJB6Ugx2DCwCQqsGfSouqKRQxwIZ0TyYHh5bhWKS+hJK1Qgtbi45Bhct2ZtSIoe0WdvgbLXTRmEvb5yQ8NIGLI9+PJLZ/i+DOEmc6DUer0AJmm1SBOXHNX/JwXZ5HndKsw9aU+XpWUSRU1K4ikQKxO/nUSRchZEbhFzJBvT3VBnWCpBw/buB+EoHJECUIMtjmvucwI7rEsfIjVh92AUha1uFySkHhp+9OHQKlQX8jduIhpL4k0HV1YR4ugoj2QE4fg1CoIsf7ayx0GwyAFesymwwgE4ZPDy1Xf8fpNVkHq0OYfdNklCtRW0u/9qobz6aPdhdJtksJ4oQnrQAZQktuYhgeNBJRkdC3dR8iBGvrKso89vrBRDz4DY+x8w5gZkXyxfajBAbEEShsEihh5eVFtSEvwyzV001ERf69OTCm4uoSUKboaaZs/ThxpUSfo7N/eEZCMFWVigV0ySG1Gsw99+evlmShH8Bt8AsrfvoogaHVU/OwJVRVbhWbHtstmRAagsTC9hiNwKWu+75BMXJJcDsslWXFxKEiHjNvbI2jxzmKqVeMrvWbN3UhAsBjFkIxEJxqufXr7MgEivyztymv37JAp94kADbLvcwnlipCdvR/7DPqF/pzN3nB4HcLjZff++y8VF7X3QH75Yyd0MwqwldGV1bX7enK/VauZqLWeTwqwlQVQfucD066kAbvz4vE4Yj7+npcWDL1UVHcGwzdsoDKQefL70B9wBI3Nq8Y6EmwrVExUUlRehhL1Wl0RBsvm/UmEO7+r19Nvlfiq2OnHYa4RRe6QiOK2uemKSjU4RBIpwi6DvrX988xgYr06Xf5vehtAFIw9q2umwH1LxBzKiqFqQVuz6ppy5eMHv0KTVbRFHNByGjoouHwajHdePzD0InUd42oYICbJGHiEMEiXZKsalJUE2OmpEIZC5ubmF1O7QVZSW//gZarz7cpTeIKALJriLGLptlLXtmwgcLk+IpIfT7KutiGwdTVlm+NkmQFqtzV44HB+jmXBfdNnw/ehmpZExICsiOHnn50mQNVRWraYGLtUY09JKbgdBkLkFkGCbiC0iXfHl3e8vsdb/KM7vmExoUrTt5xS9tMVAOrVJDwcdQ1meIhgji48gxvjb7m1CEQKJjo/J77CM6/PNCQrh4U4sCbuDS0uTdUUcBPKoNl9bNVU38fKlpRSBEgscWotKEu/wCxz++M3Hdy8/5vaFnAQ88tq1W+oKyFXuFHTxfUxYRNFWitCGkPsjKUGrF3yC2YfHx+PRZrf7nljCkMaUYUSSbNRTk2DM0jQBENueX5OKPKoZq7WCIktZs1c4fhfmKgsEIk7Lpgyqx59/NErfsyBqMy03IZpWPv0wgtMdmgMpsugCu9IM/GwTBfUPp00EPQTvtxHW1fjs7Ay19Z6Sq9UOEFyEMtxVEexxstMeV0hFNHAQyCqR1LykuiwvAZlSBGafWwCI9X33zeP19fV3Xw7xvd/zipTkdELlp5n3Q9opkSCtlsO7WjYK23iTe8anTz3uguge4ejbt6vxeO/k5OzgbEy11cWi/wlJLofRTd3DV+MukOBeqEBsyQFFCIZeqwnIdk4SeGSOHwRSttax3u0eyXPPK6LmLDy0fbI6vN7uyhmEp5FuFxKEo/He3t54fHXFMoyH46vx3tnJwcnBWyI5GV992gQwmabt0LYXtyN29Diy2OjSItQM1xYfEghcskqlJTFW/wJkYY4XZFkkkMc/f1yK79JmQVgQTx7KEHZ5Z0K79IA4WrLrtaAHMD5947M+ODnbY5w9+uvB29ev3x68fXvy+vXrg71x2Ntk5ZBeTHJ8XZdp5Qne3WoJyMOHDym7avPz/yfT/ELaTLMwXtMMmmDFqxUR9sagYIqKiR2rF0IuwhjMdmOIzCSLMZhGC2rSnaJRNrPTpkZFwSbBXatW7SJ1B4zQQFV6URxBpFDbMsiIV4UOVKyU3cUKswtl9jnnfF+i9m3R3rT9fj7Pc/68X8w46O9mUaS//zRIlYAUqSAlhQTy8jk71fK5IiwIVy1NtfbTPBkLXrK2K7s5Hsvq2tmPby9sHG4dHm5tbtDT4/wrkdjY2Egn0unFxa309vHS0c4O/h6KWA3k7ENKdu88lj5IllIxYK06AjESiMFsNPOxMEs/K3JFVaQqo8glRZGrSMjV2TcV9MwCkqeWE2mFpAcae7Xpzjz8D4AUr1EccNTXo/0XiY3DxcP1xZWVR4eEktjY3Fx8tLKy0vPggTc5sZ5+H4e32FxOa5gWmb696b3dA77FUkKucgBEryiiYBCJ2dxsqfws7QJySTQprJx9jEbY0HDvYxU9vCiSd2p502j5TVu1pQO1J+win2NYBw+chc69/2IhsbG1vgiMlZUJ+vIP7+1Y7G5nZ2fMe7vVG02uz70/jsf3j3bQH1G4wrQlR/bmd0/6s9Ggwqvno4LgmI0ZFkuzubIfzb2RURRvXShkQS6JuXTXdLrKN1S4fnj15JwiMvbKvVy16WCeCi+mJh4Xnc6aGqdzZ2k5sbnOP/uoN4bnvxu7/cAbuxv629DQt0ND3aGYNxadW3j/XvLuoaC0AyUSmd9dfa7NZkOrUTkkI7kGrl3m7OlXQTLL7gVxFo6khJp75X9eYsr6+u3js4ooFw74f3S66yeTXHmdVkzsmJ2aiCO+sLE1AYpYa+vdkN0ewmGIG0M3cIaGQi32UM9PiV9+ScBd6PUeZL4Ja0A4PL23+qtRW5zRhEDIWWBgEL2AGBVrwVwI++UrZ0AKCaNAAZGtRJtHzb1hGDTPTm8KXHYhu06r++8unEVdowYTvNPqhDg78WXi8MZaO1vw8x8a8vn9/hv+gD8QCAQDfqD4/baQNzmHs30cZ03ws8Bkg/I3v/c/U9ZaYio550Dkt7m5sl9JSYVJSEiRS3ykcPEVMH1q4AkWquGGe8+uZKdSHC3roTN37EVIkBQEoVkWYXctbSc2J3qiMRJjyObz+en58SsY7Opqa+sKBgHknxrtSU78BHsdx4+gCd1I1LTXYAfeu/POqGDoqlkLSjgYigQEtctgOAXSz5I0EohJBSGKAgmJck2n5UHhjyMfGoYbPow8qXprkRd6eTIC6XSNv06Hw2gDqaZ2FKsUzOU5ii8gH8zRbQOFHwTBtmDwT24+Y253V1cw4JsaX1tLTswlto8ReJpfJiPhdmv44dPVA7PCoRVT4RjIWQyCImzQM4XRbDgLcu0ak1zICnJRyQgpouHX1FXP7tEo/2HWQtd/PFszh7b5twiBQAoEPZXCnL6zv50mY7VCD+IAhFs9Y3x63e624E2ffXx0LZlMJ7ZRulw0iE1Ptjd5EPevGhUOXbVeJhNxVhHJ4WAQg8FsUEGa+xuVfZckUa1VoJYtdSeRu0RsV29ou5qVK9k8jQJS3H8CZyEiTeEaa2rGSiAkCBlL9Ghra8Pz9/YKwyCfMagS9NumRmM9PetzCyDZcWEsC/ehjHsiT0/u05UJfYCCR15u58QBEIfe4QAIeYtYMiBcf02mrCKlBWyti8okT0OhhpxE4biMfXf2C4tGJnhysE5rvL4a8cBZVjxCagYTuce1v5zeehQlQWw2uIp1GBzAL+XU19cDxd0W8PumQmtRNEYmwWBGA4LV6tpb7bDwv44fJDjqMiDwFoPoeeISFpAwSOMpEMpIgQLCg6MSkTx6zaexyM5rUWYTDUfdqL3+NEIcHoyxqRma/1RBQvYhxDwodhocGKjnM8hfB0iTtkDAZg+tTazPJRZeYFbBGg8QFLBpNHeqiGQsvXpymcQhijgMDohiEFGa0Ur6GaQiC0Icirf4UwPaPPWWOk/uzEZkyKI3n/RxDG3xu3kXKYKxLzUzg+rrOXqRmJuIxlpDYiw2E1GUlZXVlxFFWS19Y018U/bRaPJHaBInEiw1LvxrEQ4J5NafPmSt3FxRBCAGNSmkiAIiilSRteAslgQcJTpRhO9N5d5PzYdGQkKvTI0H0x4P2rmHBUnhD0vL6fUVLwTppqC7CQRylCnPD5zaWiCxuygm9vG1HkwryxR4SGKl2X/v5Al/wqjOeAojNzcnR6xlIEUMZoeSdwKhkFQIiQkgiAhOgdIQ1Y878ZqDnGR6CI8mXLJQfb+K0F2CkwRJYWtlZ7Egdhs4kHM2Ez8/AzARgwyOQRKbfXQcpetHjPQIvCtMy7BrfrWjWq+rO6sHBMlha5UbIArhGLKKNJ6yFoEU5AsISIo/6kQSJRNCUjnC9zNqN9Tp7p+45FaEQLC0eo62E+tJcRaM5SaQQeb4/nsiAQJ/K0NOBt3Bm5BkdDyaTM6lt+NcgzE3U0j0ddXnjAWSi5IRg0My4jhvLSZhRUpL8/NLuQAXWX4Yefb5eTv7BUDyNBmQd6suVRCAzDg9+8ub3ENauv/qD3S5FUUghwKieKuMU+IOQpLQ6CiNwontJbRFWNTjebj3m5mK1hmSovKccgcrQsbKiqKGveK0taBHfqm0djPtI3IwnwzTVzqzfE+qNBFdof75LgbXpizITjyBpn67swW1NxBkkIH6jCK1wiEmGxjsdbf5IEmINKF2so+q4UmhbM2f/JnG9rOSCIgDIJQSouGjgigkYi1RpIBAmq9mSIYbVIzhhlmZ35mjECAd82jqTVYPoo6Tcu5vy5TVgm74l2DbKZDaUxzI/UD9wADiHvCxuSjwKF00PWJ+fBhZvc6z+xlrlefkOOj5yw0CIhjnQUyiSL54CyTmr9+OfH5eoo9oM4IA5LtpgJAhCGMm5YkvbPX0KGMWZYSbOZGoHKcEoQJ80zcFScbHx3swdb1f4sChM0536M8dKlrlApIRg0kYpFFAuP7eVxQRkCLjq7pCnWwE8saTPjeTd/kV8lGsGuvnEvPrPsy9VgIhSZxHLIiX516bD9XX3TvGHGo0+A8cEQjSi4nLZiNJoEl0Ip04PiJzhR+6Hn5nOM9RlFNezr5inIyxCKRZVYQFqbpwqYBB8ku5/tbJ9Muv7oo16g2mRd2l5RM4fzhop3Qqzpqxxrlkxe6OhlB+fTe5/EKRMrX+cu0tU0B6CYSsZb91i9wFcy1RZw/PWyOfms8XrSKxlmTEIbUrM24JiEnSfgFtJF8Fyck0EiJRbpnkZYVSsgp1JSWFBihi9XA3JG/tLFDJinW2hHiCvxkkQXi6KsscJSyUdQEhEvstCvxcGpJ4POHJVN+/m/WyfORmqm8ugZQ7yssVimzVaj6XEYUDICRJSUmhAoJnV67LNHSnnIlISUmJ+XfTLIhExBnfXE9y7cWjfUPW6hpjZ9VnTQWIWvoCSWiaD2RIxr3Ric0F2hYjfU19nwyyEvIWwt8cORQSAcmwnAMxVYi1FBCShIaUwoo3I68+Pq7U0FZSbOF3eRp1ByVrlZQ4DqabMB6lVEG2JpJRbyeBdH/zDU0o0kcEQmHISoK0d/3d5/NNdXfbQ62xaHIrHacVa7Lmy9eyo+dKDc6VopUF4doloc9Yq9GkxJ1Afs8cAmL8+IEK8NWXT7TczTn0xepGpfuZvKV/vTeJ6VdAKCGPemiAb2n59sY//SLIYH2mDQoDGoo0R7TENncXpnmb7UZ3C4Gsp7fhrXBkcvr1/+k2H9Am0zuO6yzEFjsEYaUrlNuQht4GO08F22643UCwXLezW3toJ++JvaZhzeyseFrsZq5tUNstl7cs26Rv+vYlJDrevWLw2hhxvM0fssubeNc/scmC8WZT5W2gcaiNa9luv+d53vfNW2U/apEQ8f3k+/39e943BEPX141GDGLUW2sTiKrIXqxILQZB45bheYPSDj9572vEXdWqr3DtrUGKfLE4MYC7IUQ+6gNnAYipr89s7rxwqnsel15FAoWCxH6MApp0n7rQaTYfPdo31E5ZkLdg+j07sfCSpIW64IKzMAg0RbV2adbSFDmoU2RHLSEBRT693nT90mc3H95raHqEBqx38O08fYbsNBje/erjxTY11R00SpFBK4CYzeZkLDYfCq1CqHYqYZBYq1sNzc/HkuY+Z99wq8kKIBHaAYq0LT79UM1wJUuOEGttAjGSGvyKIjprkRy51HD9Jto4vvuoqeGnZCupVscsJdUNO08/eTFxThEkwWMQBkBMUiYjhVOpVIig4OnkFYyLa2urq6FYOJODKHKUlaIsnkgwjo4hFmZDBAOD4PnESECMmxTZvQnk9F5VEeSsWpwjYK3xhkdluGi919D0rzKgwGuhdgSIQW5lZtcXzx7CYxY0dV/E7/EwFCMURTGbzRayxdllKQkoa8hJmxRZgwiFkuFcMVsoFHj4I+Y4i8cdjKKFZGE2/BOFQ51PVBClahmNpQq8b5++jwAItMPaWuQtpEjF9xseotb+1vbtnzQ9L8P5UTo3I9a6MegX1xeuHka5/td0lA5GIm4P5xZ5HPFAIB6Y4guz4RiIglO9xHFxNZRcLhYKU/GpOF8QC/DuqYLb447wMMtfXchyt1QQRRljlVq1tNqlgWgNca8CskMDqYRZq+EmXqy2b7/XdKmsulp/sEyefjesjfnl2acLH6BzIBBEDAYjbsAI8MUcWEvKFAt8wOv1xgs5JEudpgl4KpYR+Wg8EC9kl8GCyWSYo/k4L3tkFp2nLK7nQiVrGdSiBR0RgRwpuYvMjdpmpYHU6kDuNnyqgFwhICUOFeTv1Fgk+uLjq2dhjgdBEIhciMN1p5KxJIqUVOTRDR70Uqgf1y+oV6v9SU7k43H0zjC8FUXSLOVEXsy56XxHW8fEVDFmUA57FVG2GrdWVuLyqxhMs9a70BNJjqizFoDU19cDCbIWAcG7LgHRIMrKla+61NxhfBF+4A/AgY6twVmyTEf5opSEi0MYqXBY4mT4qKNxVhRiq42kdvU73SIbjfIiF5ZwhFN9UBhMXBGBTHac67i6SMcMapBJaysiwRRkUNmqsCjW0nlLDwLlFxYrAlKGFSnT3z/CFDUAMrPkine8ffjHPzuUjoKzIm5ZFIsSOCUFBIIbhSBwHmBh2aCTjMH76+YZH83SMidZLYKdvIexSmEpw3GcR0yfazt39iod0jjIQRACIWVLZVEGFWIttCIeVJJEB/J1AnKfzFpXmj7HTw/rnYVqluHGHIC0oRufbeh+CKR6LsdB3ZUYQQ7SkANRnkW3STjOTftk5whZSxq7Gb8vwlmt0DaCNM2yLO1z+QGYy2Q4T9CL7plOybcMeklwpmOQI5tAjGRu/EiRRFUEcQAJLlsAclM5RwEQTQ9Ux8rKD5SXw6e0c7d9Y46f/ODtQ4cHiLM8HApBkH0kNcA/gOKyw2tui3keg0A7v0YxVmh/MLZDcWMhW55FWZ9LdgucRZAdXkeUL3A3ShgVOEW0hoh/SOEyKgPwR5uSZAvkukKiAynHiugSBJ1kYhBDVZXktwcdV9FzvHEalSyLBa4YxGAdafhgJycWpwpZEZFYOEYyz+N0r+vvvtYKHIKfZgtQoicm83mvw7FC+4Lo37vjwCG6U7tfA8EkJRatcJVOhN7UQOrr9+yp/2FtLXjr/4CoiV4Otq2qCo3ZXVBh0+mJOHbWIBqXaDaaTpxrg+k+kRgYCGSLInIOx5gu/OJ84/6LdSNdLRRDWVy0WAhMJvKJxOJkR1saSGCXsVg8PKjjtqqdvbSx4/JLfpFEeQUESIgiexHIHgBBWVJZiUB2vgaCv5tXA4rgc6aqO7Bpr8QdDm+A94EgHpgz7OhIOp/oGPhRogNG8kRg4h852eWyQ0L3df0K6lbjsd/aoPvb5VwhEEjkO/L5u5fW04l8lHZZqEHGIoK2t3vXdILgBUsFMRpx7dp63Gh8HxcuDPKGPklKIGhIUUG0HMHxzt/Q4fKBGpQiVVWGG8zc0koUNXEWBPFYrO3tg66lFUc6vfDFf/L5v3zbkf/Gejyb4QQ7kLQ3/xxA+rt7KIZhhEwx++RFeuF3gfzCw5PZuHfFZ7e1U4OUO2K3j7WsGfSKVBBFKlVrQSggULj2QSsh1tIrsgtIwFoY5PlDEuNN95S/PXw0XoZur9YQQapuMHDZLF1g44UgzFmD7a19Jgtmyz7/Kg+65L0nHy/TcirMCIJAffnL8/sbR061UoxNSuWW//34iTefT6fXP3tZZFmXneo9Mzpo9cj2MbteEfx/HSkpYlRBjh95n7QSrEjp+GHLDiTIrj2kbAFI6WRLi4bxsvL7uPQijiqkCITI8jQMJxbqDMzvTpvdt/KMzz6ZSnu96acfPn4pbQhJJ/QVqvfX5+saj3VBqjtTnJD678nH6zDBLPzmZZF/xo7ZWnpaAUTwz8zcHlp7pR8aSyCvKrKbKFKSBEAQCfEWAWl6LcYrag5ogmz7PWNfWlpBICJkCID0wEI1bLMvraywYhaSZ/3JcrEo++2dsaSVA5D+xv7urj6rFDNDdZPl4jKMyMs5EVqJn2o5erR1dLqd87tmbEOrBnxjRwuc4NhaKNmP4x8jYiGKYGudPqiM8ShFdoEi9ViRu1c+fz3Gx8n8roB8C5IdQHw0Lbo9njHqcstRWPeckPE+H83TIg2NnuOkZGx+PilZqd6uEQDpdEoSTFfwCufOyTALyD6fS7D1Djc3tyCQubmx3lEMopHgDVdnLSSHIooGoijyvT+XQIi1Hn1nZ+lASInqN69UoK6ucGwz2ub88Omjx0w8ADJ4uaXnhLm5xTnE2P0u6HCyLDCS0wyrYiyFQE6N9I+c6nSawilYHuElRoDxBD3kwQy1DjefaD4zOm2ybMxQow/WKjYpQvqhZq338e8SyBubhpQttZAgONmVMzr8xEBZacwqxw2x/H65BlLVOed3IRIR1iJhbHC0t6e5uXl42OkcslJWqE2Q1UOpWCg0j0BsvX88BiDmXhOwodeSqSEIp8npdKInIq71YJC56cu3/3nHsCn0ICQQiHKiouWIWrVq93xzF0oSPUiJpFqb31EXgXa4DUhWZzYQCauATIMkzc1mQAEW+EFXCL6CazY7TTabs+sYuk3V0mvqQy/Oo/m9E7yInoUwd3aeaLk8PW2yWqYfPPhyX0Up27V1hJTf47iPVKog+mRXcwSMtYtIgrf2GlUR8p0H0hEVZxFFtv3g9sbGnMu3xIq5jDB2e3r0csufTqAHNjrRAxvmpLkTkgHif2ycX0hbeRbHm5hJajZXBB/UCIFyRbkxOAl1JZksNPiycMeMVUrqhPWGQIgT1PyhBYkMtGKSaarUWQSbh6YsMsPOwGIRVqxTppDqwlShgtIyS1dqZB8caLtYSl/ahz3n/H735mrnkv598X7yPf9+v3N+PwDJFQrBmDKrxAFk6ErsKyRBltQWTkLEMrGofIAgo6G1/eoUh2j+CMQAIIYRHn65aWkg538HBCSBSh1B8ByjOsvGyxMefesEYavy/v1d1OS750vzC2trxWJJjsZxWgNecItRzE7tpQAkFwrGUkklHg2mg/kYbnnt0RNO0UxHJlqqVtfWrnw5BILcs1otJyQxaCUKj1cqSGfnaUXOnyFf14OAIq2rD3duPrm58+Jin1FDaWxrY4LUCbfWd9/vzkM2ebS9NF8hSeRMPK6kUooSRgbc+kWQNHpDNJVMxeR8MCjHvpqiPuLU7F54VkmNjWUyRwfV/f11iBXF6murHkQLvwyEsfAIzArgjxThIJqPmFaeDLMmD05ttdb6Io0WlWSjsnsfUvHdR8+3FwBkv3hQol146q+z7dLPpv4Sy6dz6XRajlOzLQj2p0x1UJ8XWZLh8BhyEEgpWI21s766bs2u7qKwonGE+QhFrT9rIE6o452UEIHDzuIv28c23Rj21/pvr45bjcZ61qlqbOMkQmehUpmvzO/e/e/mcgW8ZL96EM0o4WQyyztVADKLDg4gQypIqQSKUDdObTCMHZEga+tb1Wr1gfWUIrhAVKMWeopg4CAnFHGqzi5xEL5qb+4/hNQ+/OTGi+MXN3AOxfe21cgbI20cRBDEd+uV3cru7t3vNiegtlgHkCMEwd56B+41wJcejicWASSHiigAMg5+lIL1Iu6p4JIRSMaODg72QZC1VLUa7bGcBKF2lT6PCL8btZwXaIeOQMxNXBG0rR0oUg5X2YDAJ4/v+L/xvTDynQdyEgbSeaUCz+7uvzbBSSocJJnl7TbcqQZB8kEgIZBwBhWBgBAGkuuE0tFBIGhYAHJQfce7IvqisfkEiMFQS4idOtPSKQKaqCCPf/YNP+wzmfgER++O3/9q1V3PJGnkIA2CeG8dQSr3n2/rQTo6NJBwPAoOnssVNJBxAFFmpzrY1rweZC5VjbdbrG0qiKpMDQR9BK1LNS1atvfXplEQpAkVsfPU3n/H53toohk6mj4xug793xyq7VwiQZAGUfwaSSrzS+Ak6O4EwjrSaDazEJTi6OyhQrGUSobjDATigWp8f9SBpOPyPa/b63XXW7DPrinTjJpQHkGjAh8ZMehAmCIIgsOAAGI2mzXTOvaxzV+0LHaLwMAdv+8iIyEQ9HWc+TiXWIdnYelXDMDrOkWoVzibTGI2h3wYSssQzRR5HEiiCoYDArl+XQey9foLt9cNH6gfnoEgbKCRg7ClrkAfABHVnbr2npMgniY7gKh55KbvR9rYYnLQr2O//62Rm1Yjj1rYQL28N7e+PrH5dHphfoFsC31E63lms7Px/GghEimkoykcdggGh9KJOHBkub/XQNYe4PfEQGDdY+GtduYldWRdgqCyCHxbu/00CCpiN/Pw2/Wj79CtzQexk1bd3/qftNabdCDAQa35c+9e37q8sTnBQcbIbDrYbFY2jHm9UC7n0jEIZ6noOMSvfCKFJKwd91k2ydPhaH+9ye3m9w4hiJWJQiR1ACEYRBpXNIiEJCCKtb1Hm+LA0+CgiBltyw5r3QZh1ec7biNFVMuC33f8rwbcmiI4AtnQQB0ViNgOx72nZcyJAHI0hnbDRs2y4Xge7KpQnskFEUSJlnAGeDEfVbKsnQWChBnI2oZJd9UNFXV8Bps7CVDgR8QPfwydFgai3mOhgTBFwEWcjeq1TupB0GP/8Krm7DTLKaoNVIfDcXljaYKlRB6A0a6guErkJgq5XLlczMchUSIIcKTTJTlDwrE0giBruV9M2j1QtF1jYZMcVG3jD4TXxwEmALGhexKIASWZ7J90XXD2XhgYcGogTQjS8ND3p65GPmbKD+wajSs+/wq3LAbSwGcMWD/i3XZ5YYFA0LjowdC7OLGAM+WRXD6mMBAo8XMAUjpSslniyDCQrcnaVVDPvLi/jGaFv1i0BztGkADNzBCPIEIUs1o5iNNVA8GohWMcb33fYvVL97wY1UvNVof9j6lobGysa24+DeK4t0mSVA9KKEkym5yFPB6N5cscBMv4bJgUocmIKJAk4VE4R+h1Ky/mnjFBAATSOo3FqyDiCIGga4rMxEQDgEAABtNSQey68AsgbGD2rOrr8AeCmKhCYVV8g8g4HAQSOPfrUnliAkp5sC0gwQhVisXj0TSsFMHbIWqBW4RLVD8uQnaPylA8hhWFCTI3l3igVqVeNlnR5vXWW60nQQKiTWLfHYkCJiZYLF39PZOuyd7eSb1p2fWmhZchnVUHG/+w4vOt0GFxntdFvR4OaeRpBEhmCkWSRFHi8KI4PZ5YLJSXHy2XC/lwdkoJguND2JKjGViCyLB0AQ4ZORbJsk7eM4Zzv942vvypQ7uSRBusYSVbIGAbwR8v2ATLIID0E4izBmJnPnLs+7mXjuwaa/c6nD32Da/W60AadK7ukCTHxvRSOQIgRRwNimdk+NZxqZgAl1i+/9tyOR1PYQj7voBBK5bBiRrigbVhcS63uMG2yU+BQFahjFhHY1giyIEggQCwjBCIaBnEbo+r39Xb7zzf++kZu7mlpUV1dgi/j9XJX9IDj7jd8L9yMg52QuMkhyS9ni7PLEHmK2JZGC0Fg1GZDlrAEj5Xnlhe3sZVPKywwNtxjY7TG8zCgsW5Qm70n3yH4xSJF1yeg0iiCBR2m8MDICOBgCiBpUGGt/RYe1w9rt6eXieBmGsgkBB31FvjPmGmZeqjhFivL080w0KOwIPtcgSPvoAkpVLpANIeHroAFNxXQS9ZzAEClMLBfCKKoxskCZsGLBRGH5zc8X/GnZ6vrQnEZgPLt0uSPRDwBCTJJkliwNZpGOwZ7OoenHS19zovDJxpIkVY9dsAJcqri9R5007vUImC+/F6EAd/qLNya7McieAQRzEdhNgky7STQiR4Bgb/lQdTyyMGbp8ASUlmHHOFUGKy1mnVCeOub9NAYK1klgJmSTJLHnvA47HZPfB/EIG7DNbuwf7JQbCugZOmVYdFI6RZzdmNZ513/MOfulVFcI5e83Pk8Hjs4O2RyAzNxZdKRTCrxVGIUPDe+O4yqYO7LHyfJZH48odrjORqKBS6utGl6xmrllUDaWYgLZLU4vEACHw8tqYmm0cy2AztoqXP0NPX6XK1O7ki5iZWNLIy3kR3RJIo3Yd+/6G6GmGKnAJBJ4lMR2YgY8DrHVwbHwpN58iYEvTmMpgb1I1KHCnI5n74+nYpc60UHLp6NT30y2mOZ/yGQV6jwE8EuzITSAuB2GHlAbZmCAjtAUOX0NXX2d092HvGrFME1uyPfbCwajWpQUtdWLGopYI4dKblkTy3tqdDoUhkNChnMqXb8vQjCFXl7+H5DzwfPnxI7e3tfcC/4//lpqcTty9lxjJQ2KevDiW++FgQdh2T29vGbAu+fUeLRwOxmyWz2dbkEQJCV8DQAyAj3ZMAAtG3hTIi+Yi61GXHNF0rbKnLOZrVOkvvIh6PJ/B0enR0eiY3Hh2DN7w28de///S/u2/evIRHg0GKly/fvPntH//+W/DS55c+h/A7PjR0ZcN4Yh5BC1q8fIQyvg4V4SDIwkDsHsEh/p+Nsw1tKkvjuGklabKJCPdDbm8gVGKQEDP0ssMSx13mki+K1bAbSpyKtcjGXrttrfUKwhCmxL7s7gid6X5oENQdSrutsGzZJeOHlnFk20JsRWaola6VCr5+6TpM15fGirPPy7k3t3VuaxA/2P7u//mf55znPOd4QJGQJxFKnNv1qw2hhZ2mCSo+fP5CFB/27nlR9QszHYo+eiKJsNOx2qq+mtP1dFP6ULa+rq618/Sj//0Ht94IZYSVeUscPUtLywMDVzJ18LRiYSVlFKu4rc2uyHaeQcaF2wHECyAxVY2pkgzLDs3pDEoIEiWQaGPiAwtEEqMWSJL4E1W19u7BJuY/Xn1QxTeTBvxiCk8cEUTxBgXJ4UVdT6XTRrb+1Kn61gN9Vx4NTDx5sjC1OEcRBs/g/ZGe2UJh7clXj66cztfVnarLQ2gZxuw5Wyeuzeu44g2I0ApJZUUUWXWiIkGn4tNCroivutGTQJDdDCJLpiJ48oIKdFSi++Th1xVmE8p2UXZgkEjQ0gNW/CiJziB1rZmWnvX1Rzd+KBULxcLCYm8mM5iZff5qcrJYery+vtqT6agHEPBIygBBsPMTNdmQEMHqcWsfA0BQEVlhEIlCC0AiIU/EF210RTXw++73QgsbZhNfX394+9Lth9d/m6iqEGlXgGwLlVM6c6gSjsAIojd0wG/YCrOTkdXV9UePS98WJ4vj/Tt2TPb3a/uKhcV1CLaR3mYAqa/vQofMHqxKVHHPpD2y6HRSrZlIQuBfBJEkoJAhgWtOGcwOedITCQkQ326RRwjES43+ATplVUGXlPIRSrvXOYtEyhwSlpOUyWkg0Q02CUiyCs/6+r8WS6V+eCbxY4E909PS0VHfWp/vOpRKtRSrqUO6usIC2S4WV3Fzi8xRBlFlBUBQEQBRIL2UQRy7t1BksUe8Dlw7JvjgmzibVFHBPyJAgoRQkSDtaJcDi+piU3Np8ElDHl52c2dm8PI/VsUzNTk+uVh4NfWWfL/SN5iBmW9ra2cbOH3qwwq+BMXmkUCAJvIBLm35TUUkBAkrSgxePIAEnZIvEnQDiOaq1qpREQCJmWb/5e2rV798QHdx8Mk3zCasR6AcWdQrEdkAoij7FiGX6EZXa11dZ+Z4b89lfP/0q6+urK6vclLBgas305HPt3ZiZLWcoX5vbCsW1tiOm8egRMATMGt0BOJlEIiumGSChNQIgFRroMgGEOzQ3PbxJ3v+EKd7DrealRTL6n5RBhI9H6ZDBIn8fDqX1lNtXZAhOg/06k0gxsrIfUogKzj+8gDcN9gCi658vqvLSBmFagKpsA1aeDWC1Xfm91M9KKSo3hiCKBBXAgSSO4OQIjBwfUAgMQCmSqPjv3t+xM23jW1zfEcdZxG2CG1oq/bQ0goLOSQ5kK/HpJ1CSVZXMBW+PQZ/ILUjx8hpnLd0dZIgs+esjTHcFLvLIIG4R7SZcvHBbyoSk9SYoshCEUnyqRBa3mhkVwJBzgEIcMgKcYQcXyKI29xGFP5DDgLZJjhMMSyvS2r/1PR0LpeD4AIQyHV6z2UIqpX74gFBwOl9pw0YjLPZ5mxDSjcmbRxbxSTLg5FldQLSpqUACcbQ7BhdZRAXglQmNHeUFZFREa8dxH7JuNvlRxCyHYNodhDalJAOlxaHl+aQpCHfSrMPPXfZmqKwPUZgJgnz+eZMNj+W0vXntZvaJXkNghbxmKHl95dBwmR2UkRGEAgtT8RbHXEkILoECAxbtLRnEJdLJKXaOO0h4d4kj74hYXXcrlOssAKUw4Uf9v9teGmpqSmnj+XxnAuQpPv6RtDv9+l7hFaI4BASRNdnD/4MBw1b3B7vMiPLVw6tsKSEKbRikBMBBBWBWQqCJEwQMjuD0JZ94G48zmVLv/lmCCRoCiJJFod0uLB8697j4eGlIVi9G9muA7TxPpjqARSmuN9DCxQ6457NgiDGGZsgHFh345hAPG5RxKaf7HAgiARmD4adqEgY5rgqsjhhDHCpEFqOaAQGrsQWwgBFsB2bQCr9vD0csM6Y+m3lE+RgELH3iJFVeH3v2jUAoabAdEtXG0zoj+PKHe96oNUixFSmmU+4N2fHDD01VbhYu1ERrAK5A3fRIYG4VcKuJBDII0EYWsNOCX9dVbZAggBSHYGBKyHWI05VEyA3Kx2iHcSKVNcD+i9FpVQ4hPbr4FORlH2l75+tvUMQItEbDhxq64S02IzFFLovIYP7vcc6jhw5eRQ4wOmzi4XSpqExDmJQHysMXUIR3uhhkAgqAiwCRIIlieQCm6i+aMQPyd0KLU2Y/cU/33uu38bivhh8SRDUQlHI6IrU+PTZ8v61z4ZmAARJcqmGtrauDt53n59HhCPzR+YvwAeQEMfC9HTxXZmD9kUwnYvMTscRTRBfyIlymCBOZ0yVYT4PIEolgoSqI5V2kIjGHvm551Ilg2ChjwKLLU4pXe2/+ezNvTc/rYEiSAIoOcM41NB8DEnm54/NX7jw6QXzYP6RY2MNBnDk5oqli1arIUwR3QFRx6bhNy6aMxkEFIk5IzKCKAwSVnGRKPlx4AqhTQBEZhCF+pw2gey1gbAgmikIMiCJ+vT3a9+fv/fmzXePmQNJ0jCxPY6tDXi28ghfMPARb63ngWNRzwHIxRNuK7JqadPN7XG5y/eH0ISRFXEiCCoiCbMDCMwbJYcCA5cJggkxZgO59Pl7z6VLXJhjEDMJIogi1ax9trb/2vk3L/cPzwx/YZHoem8GTYGnlMTxfFbkuKEbwJGbKyRPuPmEB16O4DbPjNg3qP2mIgAibwCRBQiMwOpmEFWA3NwlzO4RJ7dcro8fOoRFOLJYD0LRxtfWnt2buPby5bIAaYcvJEm1oDnEeXDqhECQ5oYUceRyU+M12802Krd11m1D64Ofmx4wtMIAIqsxCC0yexj8Dh5xbAitWBnEiyAOB4+3trfyoQmisUUgppwKSbJvvPTsp2sTd86fX54ZRpD29vYhJMnph/Dqh0/Nw298cLpjDOaK6XQu17S0UEzuJKPXbnVbh/Y29aJUWorIBEKjFsZVObQguUdVSCXC7E6bIgwCn2JB4BANCJhGNGrlVNnmEsyZkxeffrf/1sDEnTs3ZtAjyNHdDR9NaQguAcLnQj/CPjowj44guabFp+NJEqR2K6eNjf0b4rACmhM9AiAxAoF5YViBUYumWw5IJTjd8kW1nVto8ose0UwQfA+gqgWCuZBBvI1eMWYpihO+pH3JMyfeLQ+MDkxMzMzMYGB1t3d3dzd1tw/l5owWJnmO38+B42QGMmEqdRYVGZpbKyYPkknwZppNUristt9KuyIUWk5ZEiBOh8rJHaLLhSCi+KtxaFXSzrbV70kTUB49KB1ytYFZ1Jpksvju/Ojo6F//PoNHrYCiyXyY5OgFHHfxme/I9CIHzBcBpGnocWm8JsqlazuIp+xPvwtBHKiI8IiMIOEyCCZ3LYo58XdbkAPn8bTW9VFoAYjlEdpYRUnMNGJOeHF36DdnksmL7/Ag0uhfZma+gMDqbkIjp/ljbrBlLHvy5NGT+HRkWgxdP0uKoCTdr78tJmswtOLmxSEbFOF3yCCy3ewmiFdy7hKzFN/PKPINg3DXqvioLG/l0uiLegCGszGJz9rE6MDorX8TCHCkYcULvzDWItJ0NjE7m83MZloQAznaUmd1MsmN14Xxmp2ere7yAeMyjcdmEvaIVlZEkbcAiIaKSAQSQkVEZmeQXb/e8yN1FuDbMCNLTH19IWtRJSbvNWcQ5OktAPkKIwsDC88jpgzDSFEQDcLfBw2j1+Dnz2fb2hpIEUC5caNUTO7w4O2xnvdMYv7D/8k6/5A28zuOK4WIUsGhmxp/XB41jKx76LLBZuiSaiNkt9yeXr0gpuRwZH/oqt5aTRg00lA8Zr0m0U63IHRSFrjF5rZETbaCrRvt6OxxxFW4wjE4obIOPFxXlI3+cd3en8/3+zzG3VfRKtZ+X3m/Pz++3+f7PK3n9NsAkNYSEBNtQRwFIUWsBkjH+j1HcQFyfrX+yAkw40oVcRiLEA9hWLTs7z/55MYKgwwIjl4/D8zc70+nJ5JDyWQSvbvfDz3w7d4+Hvefv9zIWpydJRRVFV+4x6pcWEvlrAWQMlZEgDQgRs4BxE4rd2pRrDqIduXChXXOv+yqKuPclLw0wjGig3RpY1DEYtE+/eyzXYDMCGNBA7//x2kMP32YAMfQTyTJyAiDEMlgaOaDl/m1hNJRKofhMP35ApR3AAIKaS2UPKuJQWwAqQWIzVDEsBZddawuP6aXwyq5zVRhLEfEBorgsMNYBKJpr+jxLlt3ZiCI8BXJkI5O8AACxzpAoqDAu59BQoOTBKJZnF/01eFLqCtiM7KWysFeJhWxm0tBrFTZRftbDV/RwsrgwMqtqUZeX5fWMgsQZYwEgSKJZzf2by1u3ZmbHGA9wMHz1wcgzvuIJD3ij/qjaQ6Swd5Q7NbH+bWshSThydfwv1pfGiTl5XRjfjWBWLvYV7VW1aSaTGViL6XcXksgsJa9nEFIEaqI7R3F0/LJEG+ceYOfN9+oP2paLnT1UH8bxpLWWnvOIKNkrBDig6JiiLOuUCPpCwQCBBL1p6NpAdIXCvX9/I/5jTVNUTpKBNGzvszH9XwnTC0rQjFiNZWp8FUDQKyHivCCt4xjXc9aHY6l2SPjZvFaQT+SyYrIethlMUAs2uP9W1tb9KQaTA/hTLVjKClR6EMg4ANIMp2ORuG5EQkSuv/4wQZJ4jxnFF/iqC8NF7rtoppjxGZVYS1TGbcoBEIxQop0SRDVarU2SGu1d+gLkVPGbSSOpfWqIyAsCDLW2IJURHu1v7O4NTMZIw5DkQANDg98ZmuJwYrQj4ZmnjOIxekp2eM4GvZ8/wjSr416LSsUMcM+SL+lIIeKWNlbvLPV8f8PeHlaXDp1b10HaRUgJmSsEkUS+d2dxTs6yLifExUgDBTxieIFsYPcJRTpHd1/md/IJiyKYjkoVOgQ9caOQQlIV4NKIGVqLaxlNekg1XZzBQW7AFGFIrzX2HGNLizwL6rkM/KVjYWbju+e1hWRDYrdAyFYEXKWlr2/s7I1RyDEoSsiQBiCcWTsw1vSWgP7rwhEU5zOR3efnhYbaIel2DiKXW1GQSQQc5mKGDEdgrQTiJ0UEcGOtCVA5AMs8Jo0NXVWiiuSlYV7jgN9U4tBzIpFwfRJkTELDe3PABkdECAiRlgDQFxnEp9vSAwCYUVCBLL7aR6VJGFxKp6vpFb3itdefFvsXBvWOscxgsquql1WkqOW5ksgtJECkFoJIqwlF1Z8gkikX9q57KzorPxG05OmpqKjaJQREmRhE3MXJJoAya/sLOogKBTpJKvhI5TrAW8ggPQbEFksmYz6RyhEgDK58xG8pWVJkmxPPJ5qa8s4NpfPiAfo6Zpw1jqug1Cwl0lFzLDWURCKEbNQRErCIJ18mfhJ07pj9rS8vk6KFLp/pLCjDBBL4m87i3MlIBNE4vUKZ10P+IQiHPIA6eVY7w2N7twgb2VRFJ2eZ6lwOB6ORMLx1ZvbXy+5q4d7LfjK1iAUORojDGJr1UHENooA0UkqIEhl5xOU9keO/pMChHrf5dUpOAscskNhkH+vLCLYY6EQOMYNSbwBX0BaS4aLLzkR9YdiVG96++ZW9h/n19ayGkmi/DccCYfDde5cMAKWF187UaWf86c6oiJGVMQIrRDRbpXV1lpLrNV6mH4bxNVQOi9ogNAF4ieoh4V+R+GY3Hp4+yATJ0E47QoQfJVI/HpxSwT7CBoqIYmXNGGC8z7fef7SGxhCiEzH+CcH51Z2//TPPIFAEmUhE4Ee4Vyzy5Wri8Qze5uPzlaJPTpKvyrVEWEtVkSCmADSaG9tJBCVm0YJUqIIHb7lIygn+x3Lsoo4i6n4XYvTwkoIZykM8mBxa24A04McI4j3aJIVIXdxiPjEl6SIvzcWG+ijHn90ZfeDBwDB71E8ivKPSOT1YCTibm5udrnBEk6t9j/dfvNEDQU7ZS3Igf6Ep0sgdrKWBDljKxdtvCoPo7RXl1irsoIeKNBUcXJJBzk32xaPX1Aoa1kUjVstxUkBk8iOoiL2UaPlJ0miE+hLvNe9+OATw8vDl4yOhGJQRILsiyABiFPRbgfrcjBWXXMLUFzksXA8lenZe7pdOH3c1MrWMssYMZmsdnMpSLVIv1zZDZBjh80vXZwsSEXKC3sIx1XNyXPnMCFBmCv78dYWQHpHRtK0FImmCYSnzkPIQ4qkR2IxttZ47+Ti7v5/8iBBFnd6FMuVHwIkl3s919zS0ixYoEu8ra1tfrXHsVd8b/PgRcGJVZWplkHsKqxVYzc32m1nbO0i/aoN+n0XBkeNcdVtGTFSXf3T9VPz4XAkuOnxOAlD0fRYJ5ZEfgveGhzndYiURGIMl2qSjLIgBshfXubz2eyY5sQv1f4VBIfbnSMSgeLKsS70FgdRKjWfmSpuv7dX3G5X7WYBUssg1WVWK0e7cQOJeH5xhbymV4Mmftux9ObJp7dT8XgkGAyPQRBFlESDg8z1KzQpg+O8mCJJojrIcBIkw8PDTAJrhaaJA+3+IIHAW4iSLFSGzAu/yLncb7ncGAA5lAUsEc5pGOBJASvVr9hqdRAbKyJBKNhFrEMP/T/eFN7anLo7m2mLkxzBnAOvHc/cQosqQxDN8mBmZvRqrw4CSXjiXjAk+U2AXPr+dGyayvr4+ODo/d39G3/Pb6BzRN7ywFwXvulyNYv3lt8SSzNHPrGIEeHMFo9E4m1TJ80NR0CojlCQSBA6w9FUCvLkbA+0IIxIsK4ueABniRg59BXlLS07gDX7IC0OJ8hd/ijNnBQZvoR3+swg0elp+AqCINjpyevfAwiihEBgrrsuzPwtVqKFUZiEWQ4HeOCMeLdmgNh1EFUV3W97/fIxoYh+kq1x+b0Mq4q/S0klNYZXzuAQdcQpyD7Eor1vPC1JpLfoVkPIQe7ysT7R6RjtbV2krEWKPM9vYHmFztFDJM++w1OntEVxEkyFBQoNNw8J40LZnPK021AQdRBVtap6G9/eMVuguyzP4o3uWyocIMBZzQjisC7nzvXjnxM5i9otC6ctp/Da2vvvT14dp10TWp+Tt1gPCFKSfwlkmqrhxV8KRT4iEGrmCy9efEuxfO5ulo5y5yLzt3u6M/HcIcohjMsNkiJAamwC5LgOIk75n3Dc6xfD0X+qJ9NGFKQFTOV2IaG4rxi5VzSO1F3gWwkAJa6OjlLe4vX6RDQaZQCSw+sVqZhBQhwjfe9efJdBfoO0Rc38nvtLr0WmlhcyLIE7GJ5f7e6h0X17Ph7JAaNUmJy7OYeKWbCZKo6CqA10I2K7sUJ0nLq72kZhwRTAwGuAF8SVsoicJasIFUQF7vYk6E8fzk1OXgUJ7zeA5BIFCeUrIrh8+TKXFU6/1KT0/ex3i7cA8kqAfN7y2sOHDyPbf3VF2lKZ1duCokeyrGbmU3G3ICEWF6aTC4b724+AqHyGgw5nAmT2JsZS93z8KIbb9WUCKaJwMQhDQA9gEIgTq4rE2gAk6cMKkSUBybBXJC2f9x26+PYOxX70B7E/YNBe9+ji/+g4/9A2zjOOGzayv8pNF5/Yyp0lq4WRwhid90+opUaThoQ2GZKFyoIKWnmmW6qxybY2qILFnD/iKJMiakFsMNmIRhJJf1i2aiexpXQhqoiXYFtZA0ECB5LIZYV0DokTpyXbvs/73p3kJHstS6fzr/dz3+f7PM97lu7ulw/PNgGyNJQcUAwAqUZuF4ttBBpQiZ5E9BgjFsXWGUwc2vWdLg2EUhYtrAjklddX3v7JHx9MFy1anmIUiCkbC9zIYJsgZiYHYfgCPhdWrMnKxAQPLjoddDgc9h/8uVZBmCAw/IcEcnGCDbrgwsOHn5IgM0NTCC0iSY+WVAg7yZBJt8TJ27jzf8lQEH+dUfur31VBujp4YWevc0Ly7ZlfLaUtGgUXw0EcsoKftbt8bTmLG51ICKXbnLx5YgKJ6wCd1wJKONas0OvpwmSS4x8dZ1AfhiePEQm9q/TUN3fvfvnxNoEszXRbDIxEmY6zWCrmM1ho0UA1Bwxo7Ak1G3NZFARXYvZbe3Z/u+t5kFfeeJQtMgpeNApMDIfNpqZEZVzLvXopJA4f9gLFmrxyYmKCXEJVEWYPN+oVqhwgOXj8IzRaxBFj18clEqDc+ObuvW1kX9R2V1ExmExVQ6ZkzBbTGgRxoDGh1gQkuajcysY2hSRJMUV2Ewj9WwGhtfu1nkupfMailz6mhU1VEcMgKxEzCcKWh906BskRAIo1YL15gUtCZ3gBEhuubzUPh0HE/H6QxAl7JidH6LKy9G7Mi5dvzN18ukEcS66MAkkc+VwuG09bXjLIOrkEnwsXRkEOTs+3g/zwe29Oje8tZlQxWEQ52ikkWZIA4vT5NIuwgs4wiMSHW7fVd+vUDfQpR7BQDHlDoZjfXxsbW28e8BPJQXS+YUB5cPNCFLL8b0/M/W3pkw0E1tKMOagoNkvRbs/lUjmaeKINIkMfOTJOOtpCMci2zsgqA/k+A9k1tfqWpkWQF3CHzcEhVA6AoF8Y19ssjqJS+AgkEOh2NeZOAYWuZjHi9YYmG5Xh9bGxsfqT0weoppwkkDCFF12PlVSZODV3JTlztQ+CJJeVIFUOgKTzqczLJGEkVCE1EAWJNFjugkcYyL5ldIRtFFg1MzEoFPkPSDQgvGVIr+rdOgdAAhRauLdevXUBJJcnzv8ZIF5Ppem/tjVGo77erJw7Cd+QW47DNh5PyHvsyI25a0nqopNLM664EoUcxGGxHHW+AEGLknKZSHIWbVaiItsK+a5dDGRPhxNa8JLRqRpDdbesRxU9GAxiyuXrNusmt7p8P+h5sDodD+zbF6BiEnANDc3cvEzvpUZweSdj/lrjcKMOjgV8AKbWqPh/jURMzbwndOAdCPJJEvm8LzmTdOUUxZEhEEw5P51/iR7PjClwFKN0VNVjC79bXmMgXXs6EqorIAUbbSHFYkqhsJIEk8kwAKu3cpV1/o49YTNV8y6miBWJyzzV1/fVOxfPn6cuZDIWa7o/PclJFhjL2FbdXWvcuvkP1P3QyJELc/+6mvShmJpnrLNRanXzICGG6dLzcuT714xxVJgcrMQGgZggSeJ1gLz60/19HURR0JSwOdpDismBP8BADAmzS89V1tk7RYeB8mU1MhUIkNkDSMNDtHr/FTiOeaFIuOJ2V04Ou8cYCt3Y2Nr6er12796ZC6fmGkuUu3FwfP1sdkHUiyJlqNxOOdLOFaPRuEmlRBIEQRQkASCCCS4JLvfNPjh0Jz7doZY8rgRn0GOKcWNDQf9gcrLcS73uG+POqGgwgQM1zBRHNcQNOIFuWnonvRDEG0L69dTc7ua5c80614SJMsZdgx3Xr1+vDUxZqcZa78j8OKdxzF9weqa4uQYOYz++aFMERVQEURTw3SaqifbN+729/dlsB58/v9PEkDSTyzwg4fSqIc5yb8/tlWKQQdAwiKZq8AFxuKwkitWKPPD495S0PLFwuOF2u2uV2PC9OpGoiqgci4uLfyllN+MDg8gYZc4hR5C3nqsimXw2ThjGtRJSFmcQMZCtbbRyjGSc2awKwsOJQUg810o8VRGEoEiKgCNfWAbG/H2LLJIYbIAD29XEJcrBLnZoKeKT74Ij5AHJbyAJRHknNHL6SX2sfSx8vrh4drGczWZ7N8cH+/KkCIQPAmSn0dOlFSMfsIjdQgiiQJ+gKGDFSucmnFwRSU9SvF5IOgPuRPx2ScBxr9q7XbP3g5g4VWB2M5jAQQ/B1f0UWT6Wjs3J5JLfe4BeZ/r++yQJoTRCoZE/1da3WoIAZPHzMg5lf385FX+vwCUpoFbkVX8zOezTRmMbSIKB4K9KBUqxBAKSIlPEIUs2idmCCaHoILQhmti2gOy72rM3iKbO1AZiEFVlbCv7GQdrvLqTya9IEupShmucxF1rXgvFQpUmZ+EcZxfYCu6os5h578fyDhDNHKk1lQKP/1VBKAzkQicHIZKInSnicGjh1Jq/om0CXdsdiQoiS1NVGLzKkDBEEyc62kO5i5V5WjA+DsHuCK+YKomqy/C52HDDXVdBFkvgKJf3Yg2X+BmXBKGlg2SKvWvGthEv2VloAUTq7GwDsfQDpJc8oltCA+Eq4BeTIlhD01OKTJqyaFCNbtIVod2Z6enV1Uc/evsXfWbUFNKErrHjCTXbSNw1VJHD54ZPrzOQBSyry/1lSIJlXJQkESJOzeyZoupxfawBJM3moDhaICBxZntTxuUObg517jt1IRCR72WJQlAnTYeF/CEqooqCbUGQ5eCdQ9vbo33ohZNXvCPM8R/U3DtHrVkZ/uDMx9chCChIEyZJhJ1ezKggz6tBoWUso8jQFERbZxtIZ7CYOjS/39ohwyGiqoigozARBAomyibsa8TFJi6IOg49Z0Q4TPgu+f7A6Pb2wBQZ5Z9eloN3BJfGcu/Mic/+utDPFMHnUbayplOLeVZH0rnUTgw+UlhwFZD4xYIGwiWJpkuPBsY7SA4CoGqpSPyuFV2iyQAegUOyBK4YRB1EDTY0PahSlCvSG8tAGZg1cxJKXZ4XSdbX63//7MZ/VtQTNiQJQBwSKjuaqXxp+mUYRuMz9MYJhLTqEFWRgs0RyeTiax0sVzESulN4gKk9AGZuqCKkVLkEferMHuoz9qiCFC4NLo+Ojj5dHiISrEr8Ho9fJ3mmgdQxngwOGrPqqadSjhpXSbTA69mVlzCsaW7PKyaT3NmmiANVNJMnEFnSDnfLJxxJYFM3mYRWqJHlyRBqXIkGjkSbVM9k2/355dFDo6MDG/NW18zvQqFJkLSiq/asBfL1F7NDX3ASHlsJWUJkldba574DxNiP5tixE8RhkhPpdLrIFJG5BDyEBNUngsKeYK5V2lSIUOBFVVQTGJmdV3fowTpS9K+3bxPI043BwSFX8l1/yDMJn1Rqz0UWhjtu3JjiJGU6F5iwOByIrKzx/421fmqOEVu2FojDoFjAkc6XWWhR5eOqtPzOsJgEKBZaDuAYPKR4bKnZVxEZi4S8hcgiQaauXp0ydz8+7PFOevz+4UYbCnH8u74SjxsHp1Y0k2QSf4ig03JOvxzCuLZZjEbRHKcNbSAOUSE9iCRLIDaByoRuceZ8Jgn2CuQS1UOKqMUUMIQWCAsuvkawvTX6v2rO57WNI4rj+x8su1hCCAvtGkROPRT3klaWZSQQBLLQHmr1IApaRKjQaY1aqEA5RjhILEQlLIgc6hwi61AlJqeu4tKqpqJg5EKoaaC92Ktbq0JIcKBp33szs7tO2pBDqd0xiZwdWcwn733fj5lJTHNy17EsB4b1Vuf6pdqljfG4FqAwgzzDu+otx7MZCDSGH0O1nnchecz+BmTTbWOgpQAcgETU+lYXv7qDgcSEIStM44FGAISGmkCT0GxCZc6lMN8SYYtMoqhMY0u/TLyKYxka3otwnFX9yZ3a5fHuGM+tx8fHBwcc5A+6dV/VWn0mksHWZ13wrIvTF3TBknp/i1q/LogkE1gkkywDA3IAicStAHk/ACHJqFgukh32oAPg5lH5byJe+RwYhUHvi7nW3fvIofMrBY7xxc3axu7u7vPxR3fuXP1g4/vPv/3qt59+Boo/Nzenlftkkmv5ASwm/w8SmQ8aLHUsAUhZ8cUeUZa2cDNyawvadSkSmIQ5EP4hgeLgASABKhHfs0hLOV7lBQoVWyrrEEAkELccBNHY7QjHcpa1T2tXdmk8Hx8eXvnwxg+3bh1OqrOpbxJQ+87gx+4ov2a/5FnT/bX2MDekrNEGkdSTEZ4Qc8oC7t0t1RsLmcWcJLKGypUuYhemDxI89DJ74EzC01T2wsROIEmeTBIsJ4JBrFXaTkWrgE2WjSeXOQmO46Oj27e/0zTrbjO6GSWVoNp3AMTNz18Wx1J5AQ/fkKROICKzL8ptoBhGlEimsTSQZOFaSZlZg6ULWawcSjksccnJyLvYrKjgBQjJHUHKD6xlukrADoAsRFl9UhsHIAcHB8dNc+IYumVGTWOTqT2/0wUPm5+OVZsjEgce7SAJA0mymnGYGC61M6q80B7gPrck1i4rKrcHT3wqe01Q4EqqjAv8KsFcTAkaEk7CQDI9UMaqIc6y+KWVL6+OwyDPKUhXNN17bDQJZG20NhiNToFMp/1Bg4VZxsFBFAaSU+tlOdLowjPcr5eE+2MT5VtEmAXrRFlmzSAahBQiy0HRSxpJchiqLzPdZXa1jg6xdZ3dFlzt3OTehZHrAHJmlVD0ilFJI4j7zN0ZFfN2KFQVuw2RL1h5yDXCw9aiOkzmCIOBBLkvqQYQEWGVCHkROldgJELjKUXhrQmFLRmT+8LvFjgXrP8TOinVDdKK0bn+3iPfs6rEgZlTKxg9rLZc211z+27RxxgJjBAIRS0BElHUOm2yEkde4pHKd6ZTFuF+hoWKogqdk0RYqZUUXRZvStQE+ZbDjcK9izxM0369POYgu80mJ2l6eiGK8dedjxDEZd3UHyhxf+QECNQo2xEOMlTVBjOHAJH9cJTk61cZliomcM3JPXyhhCjLfp3CAzChJBUegHcwALNr2rS3quF5KZK8XdsYE8isGZBUCtU+gvT6ebdPap/Ot9shDNI6ley48IHCQXJqDjeL82v8QEtohFyIWUZWgzjLCxMF9a74RaNfaIX7Xioi0SSNB86yI0yyoq9o+vrKBTCKvvLNw9r7R0+fokQER9PUJmmySNrNF0f5a/vFQX0h6DiGgWuVu6xoZFEro7YDe4ClpMCTYGW+TwkvE6UinouJ+p0KMNGYJEMgVAVHIrkelFnLvm+B5i8ULhSAZ8U6eTi+ce/e7Qr0X2bTZCCOByDvuGl7BCaBxqoeNsaQdnOHFH5R6juZJM8jizI62jYe0g0gnZQD1yJRhxUiTML9aG+PORlzOxG2knzTkYUtAlkchCxCh8D4P8C/iw7mnBw+Ovp6rBdANJaBdWXFszAlXnSvzYvudhH+bgOR896JgZSRg3WIDERtQEbP4AYQVFOZhlT994dZyuJXNvtm/MXR8U5OsFkhFWl4xFKKO3a/3y/aHtppNptF90drLw+XMsxj/Pg0PejBd61WC38AfrVa0muPVOp13/nGKz6k5FReGKWKnYZhezAdc0wYzdl++vSYR6s44ZXgEwps8nHMOvUx0n894tppDic7YYuNxnGWSAClF8aYEgZxSCnx9qx2tiBSKmuEF9CJzdjK7AqaPGV4DCUqUGyOYTpZ/PH1KXvcM+Ih4zodSToLFM0JOAyx4miJTToTWnd1Si6332IYlUKMpk2bv91MZYVzWYV4SjqbkcriZndnJZ4qtYQH2SZfjUBp7YM4mhyDz3V8+fScVCq+vlJYz8bOisKPHrgAb+5roWcFIYFQqjMuDj3GZwLsdHoWl87TKE2CEDXVg+hWMcXwNIEhxZq2HwGqunS+Rsqq+iitkv84pnlhjbNnFWG++cyJS+dupPTJlK+wtR48zmIo9gqBAFIeiwv2ZtU4hxhcFGZ0H9zGDtkEQvEkZA6wB3DYvWnVK8SkczziBctrtlqVcDTIhldcqLaqpqNnU9L/YOC/RHjF3CsY/gIarQ9eh9EeIAAAAABJRU5ErkJggg==",
+      "residentSince": "2015-01-01",
+      "lprCategory": "C09",
+      "lprNumber": "999-999-999",
+      "commuterClassification": "C1",
+      "birthCountry": "Arcadia",
+      "birthDate": "1978-07-17"
+    }
+  }
+`;
+
+mockData.didAuthnCredentialTemplate = `
+  {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      'https://www.w3.org/2018/credentials/examples/v1'
+    ],
+    "id": credentialId,
+    "type": [
+      "VerifiableCredential",
+      "UniversityDegreeCredential"
+    ],
+    "issuanceDate": issuanceDate,
+    "credentialSubject": {
+      "id": results.didAuthn.did,
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science and Arts"
+      }
+    }
+  }
+`;
+
+mockData.credentialDefinition = {
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://www.w3.org/2018/credentials/examples/v1'
+  ],
+  type: [
+    'VerifiableCredential',
+    'UniversityDegreeCredential'
+  ]
+};
+
+mockData.prcCredentialDefinition = {
+  '@context': [
+    'https://www.w3.org/2018/credentials/v1',
+    'https://w3id.org/citizenship/v1'
+  ],
+  type: [
+    'VerifiableCredential',
+    'PermanentResidentCard'
+  ]
+};
+
+/* eslint-disable */
+mockData.examplesContext = {
+  // Note: minor edit to remove unused ODRL context
+  "@context": {
+    "ex": "https://example.org/examples#",
+    "schema": "http://schema.org/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+
+    "3rdPartyCorrelation": "ex:3rdPartyCorrelation",
+    "AllVerifiers": "ex:AllVerifiers",
+    "Archival": "ex:Archival",
+    "BachelorDegree": "ex:BachelorDegree",
+    "Child": "ex:Child",
+    "CLCredentialDefinition2019": "ex:CLCredentialDefinition2019",
+    "CLSignature2019": "ex:CLSignature2019",
+    "IssuerPolicy": "ex:IssuerPolicy",
+    "HolderPolicy": "ex:HolderPolicy",
+    "Mother": "ex:Mother",
+    "RelationshipCredential": "ex:RelationshipCredential",
+    "UniversityDegreeCredential": "ex:UniversityDegreeCredential",
+    "AlumniCredential": "ex:AlumniCredential",
+    "DisputeCredential": "ex:DisputeCredential",
+    "PrescriptionCredential": "ex:PrescriptionCredential",
+    "ZkpExampleSchema2018": "ex:ZkpExampleSchema2018",
+
+    "issuerData": "ex:issuerData",
+    "attributes": "ex:attributes",
+    "signature": "ex:signature",
+    "signatureCorrectnessProof": "ex:signatureCorrectnessProof",
+    "primaryProof": "ex:primaryProof",
+    "nonRevocationProof": "ex:nonRevocationProof",
+
+    "alumniOf": {"@id": "schema:alumniOf", "@type": "rdf:HTML"},
+    "child": {"@id": "ex:child", "@type": "@id"},
+    "degree": "ex:degree",
+    "degreeType": "ex:degreeType",
+    "degreeSchool": "ex:degreeSchool",
+    "college": "ex:college",
+    "name": {"@id": "schema:name", "@type": "rdf:HTML"},
+    "givenName": "schema:givenName",
+    "familyName": "schema:familyName",
+    "parent": {"@id": "ex:parent", "@type": "@id"},
+    "referenceId": "ex:referenceId",
+    "documentPresence": "ex:documentPresence",
+    "evidenceDocument": "ex:evidenceDocument",
+    "spouse": "schema:spouse",
+    "subjectPresence": "ex:subjectPresence",
+    "verifier": {"@id": "ex:verifier", "@type": "@id"},
+    "currentStatus": "ex:currentStatus",
+    "statusReason": "ex:statusReason",
+    "prescription": "ex:prescription"
+  }
+};
+/* eslint-enable */
+
+/* eslint-disable */
+mockData.prcCredentialContext = {
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "name": "http://schema.org/name",
+    "description": "http://schema.org/description",
+    "identifier": "http://schema.org/identifier",
+    "image": {
+      "@id": "http://schema.org/image",
+      "@type": "@id"
+    },
+    "PermanentResidentCard": {
+      "@id": "https://w3id.org/citizenship#PermanentResidentCard",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name",
+        "identifier": "http://schema.org/identifier",
+        "image": {
+          "@id": "http://schema.org/image",
+          "@type": "@id"
+        }
+      }
+    },
+    "PermanentResident": {
+      "@id": "https://w3id.org/citizenship#PermanentResident",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "ctzn": "https://w3id.org/citizenship#",
+        "schema": "http://schema.org/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "birthCountry": "ctzn:birthCountry",
+        "birthDate": {
+          "@id": "schema:birthDate",
+          "@type": "xsd:dateTime"
+        },
+        "commuterClassification": "ctzn:commuterClassification",
+        "familyName": "schema:familyName",
+        "gender": "schema:gender",
+        "givenName": "schema:givenName",
+        "lprCategory": "ctzn:lprCategory",
+        "lprNumber": "ctzn:lprNumber",
+        "residentSince": {
+          "@id": "ctzn:residentSince",
+          "@type": "xsd:dateTime"
+        }
+      }
+    },
+    "Person": "http://schema.org/Person"
+  }
+};
+/* eslint-enable */

--- a/test/mocha/mock.data.js
+++ b/test/mocha/mock.data.js
@@ -10,9 +10,9 @@ mockData.productIdMap = new Map([
   // edv service
   ['edv', 'urn:uuid:dbd15f08-ff67-11eb-893b-10bf48838a41'],
   ['urn:uuid:dbd15f08-ff67-11eb-893b-10bf48838a41', 'edv'],
-  // vc-exchanger service
-  ['vc-exchanger', 'urn:uuid:146b6a5b-eade-4612-a215-1f3b5f03d648'],
-  ['urn:uuid:146b6a5b-eade-4612-a215-1f3b5f03d648', 'vc-exchanger'],
+  // vc-workflow service
+  ['vc-workflow', 'urn:uuid:146b6a5b-eade-4612-a215-1f3b5f03d648'],
+  ['urn:uuid:146b6a5b-eade-4612-a215-1f3b5f03d648', 'vc-workflow'],
   // vc-issuer service
   ['vc-issuer', 'urn:uuid:66aad4d0-8ac1-11ec-856f-10bf48838a41'],
   ['urn:uuid:66aad4d0-8ac1-11ec-856f-10bf48838a41', 'vc-issuer'],

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2020-2022 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2020-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import {config} from '@bedrock/core';
 import {fileURLToPath} from 'node:url';
@@ -16,6 +16,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 config.mocha.options.fullTrace = true;
 config.mocha.tests.push(path.join(__dirname, 'mocha'));
+config.mocha.tests.push(
+  path.join(__dirname, 'mocha', 'backwards-compatibility'));
 
 // MongoDB
 config.mongodb.name = 'bedrock_vc_delivery_test';

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -32,10 +32,10 @@ config.mongodb.dropCollections.collections = [];
 config['https-agent'].rejectUnauthorized = false;
 
 // create test application identities
-config['app-identity'].seeds.services['vc-exchanger'] = {
+config['app-identity'].seeds.services['vc-workflow'] = {
   id: 'did:key:z6Mkw4VNHJ2JHnepRHsRkGfJhxLh6penJmp7wnozgspgn7hR',
   seedMultibase: 'z1AkfV2wAxeDTyMTBe7Sh2Qvn7wKoy34dHTQGhFbVD52NmA',
-  serviceType: 'vc-exchanger'
+  serviceType: 'vc-workflow'
 };
 config['app-identity'].seeds.services['vc-issuer'] = {
   id: 'did:key:z6MkiZ433VBt3jx19vBeHwshV37imwfA4FVYbN7nyEcccRg1',

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2016-2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2016-2024 Digital Bazaar, Inc. All rights reserved.
  */
 import * as bedrock from '@bedrock/core';
 import {getServiceIdentities} from '@bedrock/app-identity';
@@ -38,7 +38,7 @@ bedrock.events.on('bedrock.init', async () => {
   handlers.setUseHandler({handler: ({meter} = {}) => ({meter})});
 });
 
-// mock oauth2 authz server routes; these are for creating exchangers, not
+// mock oauth2 authz server routes; these are for creating workflows, not
 // for performing OID4VCI delivery
 bedrock.events.on('bedrock-express.configure.routes', async app => {
   app.get(mockData.oauth2IssuerConfigRoute, (req, res) => {


### PR DESCRIPTION
I still need to update tests to use `workflows` routes instead of `exchangers` routes, but backwards-compatibility tests are passing.

EDIT: Actually, this is already working.