### PR TITLE
Fix peer dependency constraint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vc-delivery ChangeLog
 
+## 7.7.2 - 2025-10-dd
+
+### Fixed
+- Correct `peerDependencies` constraint for `@bedrock/app-identity`.
+
 ## 7.7.1 - 2025-09-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "serialize-error": "^12.0.0"
   },
   "peerDependencies": {
-    "@bedrock/app-identity": "4.0.0",
+    "@bedrock/app-identity": "^4.0.0",
     "@bedrock/core": "^6.3.0",
     "@bedrock/did-io": "^10.4.0",
     "@bedrock/express": "^8.3.1",


### PR DESCRIPTION
This is blocking users from upgrading minor/patch on the referenced dependency.